### PR TITLE
fix (#67): Slack Ephemeral 메시지 내 한글 이름(kor_name) 및 영어 이름(eng_name) 필드 추가

### DIFF
--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -64,6 +64,7 @@ class JoinBigchat:
                 f"""
                 <@{self.user}> 네 신청 정보를 아래와 같이 등록했어. 바뀐 부분이 있다면 운영진에게 DM으로 알려줘!
                 ```
+                이름(영문): {member.kor_name}({member.eng_name})
                 핸드폰: {member.phone}
                 이메일: {member.email}
                 학교/회사: {member.school_name_or_company_name}


### PR DESCRIPTION
## 구현 내용

- Slack Ephemeral 메시지 내 한글 이름( `kor_name` ) 및 영어 이름( `eng_name` ) 필드를 추가했어요.
- 이때 필드명은 `MemberManager` 객체 내 `_validate_member_info` 메서드를 참고했어요.
- 필드 추가를 통해 변경된 메시지 포맷의 간략화된 버전은 아래 소스 코드와 같아요.

```Python
f"""
이름(영문): {member.kor_name}({member.eng_name})
핸드폰: {member.phone}
이메일: {member.email}
학교/회사: {member.school_name_or_company_name}
"""
```

## 기타 의견

- Poetry 사용한 패키지 관리 등 다른 분들이 기여할 때 초기 셋팅을 원활하게 도와줄 수 있는 방법을 고민하고 적용해봐도 좋을 것 같아요.