### PR TITLE
gogo 이모지 제거할 시 등록 취소되었음을 귓속말로 안내

### DIFF
--- a/src/handler/bigchat/abandon_bigchat.py
+++ b/src/handler/bigchat/abandon_bigchat.py
@@ -1,5 +1,5 @@
-from typing import List
 import re
+from typing import List
 
 from implementation.member_finder import MemberNotFound, MemberLackInfo
 from implementation.slack_client import Message
@@ -59,5 +59,10 @@ class AbandonBigchat:
 
         self.gs_client.delete_row(worksheet_id, member.email)
 
-        self.slack_client.send_message(msg=f"<@{self.user}>, 등록을 취소했어.", ts=self.ts)
+        self.slack_client.send_message_only_visible_to_user(
+            msg=f"<@{self.user}>, 등록을 취소했어.",
+            channel=self.channel,
+            ts=self.ts,
+            user_id=self.user,
+        )
         return True

--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -72,7 +72,7 @@ class JoinBigchat:
                 (참고로 이 메시지는 너만 볼 수 있어!)"""
             ),
             channel=self.channel,
-            thread_ts=self.ts,
+            ts=self.ts,
             user_id=self.user,
         )
         return True

--- a/src/implementation/slack_client.py
+++ b/src/implementation/slack_client.py
@@ -28,10 +28,10 @@ class SlackClient:
         self.say(msg, thread_ts=ts)
 
     def send_message_only_visible_to_user(
-        self, msg: str, user_id: str, channel: str, thread_ts: Optional[str] = None
+        self, msg: str, user_id: str, channel: str, ts: Optional[str] = None
     ):
         self.web_client.chat_postEphemeral(
-            text=msg, channel=channel, user=user_id, thread_ts=thread_ts
+            text=msg, channel=channel, user=user_id, thread_ts=ts
         )
 
     @staticmethod

--- a/test/handler/bigchat/test_abandon_bigchat.py
+++ b/test/handler/bigchat/test_abandon_bigchat.py
@@ -38,6 +38,6 @@ class TestAbandonBigchat(unittest.TestCase):
         mock_slack_client.get_replies.assert_called_once()
         mock_member_manager.find.assert_called_once()
         mock_gs_client.delete_row.assert_called_once()
-        mock_slack_client.send_message.assert_called_once()
+        mock_slack_client.send_message_only_visible_to_user.assert_called_once()
         assert result is True
-        assert "등록을 취소했어." in mock_slack_client.send_message.call_args.kwargs["msg"]
+        assert "등록을 취소했어." in mock_slack_client.send_message_only_visible_to_user.call_args.kwargs["msg"]


### PR DESCRIPTION
- resolves https://github.com/AUSG/anna-v2/issues/73 

`XXX,  등록을 취소했어.` 라는 메시지를 당사자만 볼 수 있게 변경하였습니다.