### PR TITLE
fix: deploy workflow에 Python 버전 지정 추가

### DIFF
--- a/.github/workflows/deploy_with_fly.yml
+++ b/.github/workflows/deploy_with_fly.yml
@@ -17,9 +17,12 @@ jobs:
         with:
           token: ${{ secrets.ACCESS_TOKEN_FOR_CHECKOUT_SUBMODULE }}
           submodules: true
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
       - name: install poetry
         uses: abatilo/actions-poetry@v2
         with:
           poetry-version: 1.5.1
+      - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: make deploy_remote


### PR DESCRIPTION
ㅠㅠ

https://github.com/AUSG/anna-v2/actions/runs/5841352429/job/15841468444#step:5:1

```
Run make deploy_remote
poetry run black src/
The currently activated Python version 3.[1](https://github.com/AUSG/anna-v2/actions/runs/5841352429/job/15841468444#step:5:1)0.12 is not supported by the project (^3.11).
Trying to find and use a compatible version. 

Poetry was unable to find a compatible version. If you have one, you can explicitly use it via the "env use" command.
make: *** [Makefile:31: _lintfmt] Error 1
Error: Process completed with exit code 2.
```