### PR TITLE
fix: Change visitor info to use Korean names for easier verification

### DIFF
--- a/src/implementation/google_spreadsheet_client.py
+++ b/src/implementation/google_spreadsheet_client.py
@@ -105,12 +105,10 @@ class GoogleSpreadsheetClient:
             title=title,
             header_values=[
                 # csv 만들때 헤더 없는게 낫다고 해서 전부 주석처리 함
-                # "FirstName",
-                # "LastName",
-                # "FullName",
-                # "Email",
-                # "SchoolOrCompany",
-                # "Phone",
+                # "visitor_name",
+                # "visitor_company_name",
+                # "visitor_email",
+                # "visitor_mobile",
             ],
         )
 

--- a/src/implementation/member_finder.py
+++ b/src/implementation/member_finder.py
@@ -17,12 +17,10 @@ class Member(BaseModel):
 
     def transform_for_spreadsheet(self) -> List[str]:
         return [
-            self.eng_name.split(" ", 1)[0],  # first name
-            self.eng_name.split(" ", 1)[1],  # last name
-            self.eng_name,  # full name
-            self.email,  # email
-            self.school_name_or_company_name,  # school or company
-            self.phone,  # phone
+            self.kor_name,  # visitor_name (Korean name)
+            self.school_name_or_company_name,  # visitor_company_name
+            self.email,  # visitor_email
+            self.phone,  # visitor_mobile
         ]
 
 


### PR DESCRIPTION
## 변경 사항

### 1. 한국어 이름 컬럼 추가
새로운 시트에 `visitor_name_korean` (또는 `visitor_korean_name`) 컬럼을 추가했습니다.

### 2. 컬럼 순서 재정렬
기존 순서를 다음과 같이 변경했습니다
```
visitor_name → visitor_korean_name → visitor_company_name → visitor_email → visitor_mobile
```

## 수정 배경 및 목적

### 1. 한국어 이름 컬럼 추가
영어 이름만으로 입장 확인 시 시큐리티 분들이 **신원 대조에 어려움**을 겪고 있습니다. 
이에 **한국어 이름**을 함께 **제공**하여 불편을 해소하고자 합니다.

### 2. 컬럼 순서 변경
데이터 관리 시 엑셀 복사/붙여넣기 작업 효율성을 높였습니다.