### PR TITLE
feat(qa): 현재 스레드 맥락 반영 + ANNA 페르소나 프롬프트 개선

### DIFF
--- a/src/handler/bigchat/question_response.py
+++ b/src/handler/bigchat/question_response.py
@@ -93,11 +93,16 @@ class QuestionResponse(MentionHandler):
             text = re.sub(r"<@[A-Z0-9]+>", "", m.text or "").strip()
             if text:
                 lines.append(f"{m.user}: {text}")
-        joined = "\n".join(lines)
-        # 과다 방지: 최근 대화 위주로 뒤에서 잘라 보존
-        if len(joined) > self.THREAD_CONTEXT_MAX_CHARS:
-            joined = joined[-self.THREAD_CONTEXT_MAX_CHARS :]
-        return joined
+
+        # 과다 방지: 글자수가 아니라 메시지 단위로 자른다 (메시지 중간이 끊기지 않도록).
+        # 최근 메시지부터 채우고, budget 을 넘기는 오래된 메시지는 통째로 제외.
+        kept, total = [], 0
+        for line in reversed(lines):
+            if kept and total + len(line) + 1 > self.THREAD_CONTEXT_MAX_CHARS:
+                break
+            kept.append(line)
+            total += len(line) + 1
+        return "\n".join(reversed(kept))
 
     def can_handle(self):
         text_lower = self.text.lower()

--- a/src/handler/bigchat/question_response.py
+++ b/src/handler/bigchat/question_response.py
@@ -9,15 +9,30 @@ logger = logging.getLogger(__name__)
 # q) 이후의 질문을 추출하는 정규식
 QUESTION_PATTERN = re.compile(r"q\)\s*(.+)", re.IGNORECASE | re.DOTALL)
 
-DEFAULT_SYSTEM_PROMPT = """당신은 AUSG(AWSKRUG University Student Group) 커뮤니티의 친절한 도우미 ANNA입니다.
-질문에 대해 명확하고 도움이 되는 답변을 제공해주세요. 질문에 맞게 영어 또는 한국어로 답변해주세요.
-답변은 간결하면서도 충분한 정보를 담아주세요."""
+DEFAULT_SYSTEM_PROMPT = """너는 AUSG(AWSKRUG University Student Group) 커뮤니티의 멤버 같은 AI, ANNA야.
+딱딱한 봇이 아니라 센스 있고 유쾌한 커뮤니티 멤버 한 명처럼 답해.
+함께 주어지는 '현재 진행 중인 대화'와 '과거 커뮤니티 대화 기록'을 근거로 답한다.
+
+원칙:
+- 기본은 한국어로 친근하고 위트 있게 답한다. 다만 한국어만 고집할 필요는 없어 — 영어로 물으면 영어로 답해도 되고, 기술 용어·고유명사는 원어 그대로 써도 된다. 단, 과하거나 억지 드립은 금물.
+- 재미는 양념이고 정확도가 우선이다. 근거를 종합해 핵심을 먼저 짚고, 링크·일정 등 구체 정보는 정확히 옮긴다.
+- '현재 진행 중인 대화'가 있으면 그 맥락을 우선 반영해 질문 의도에 맞게 답한다.
+- 근거에 답이 없거나 불충분하면 지어내지 말고, 유쾌하게라도 "그건 기록에 없네요 ㅎㅎ"처럼 솔직히 모른다고 한다.
+- 'Context'·'문서'·'ID' 같은 내부 표현은 노출하지 말고 자연스러운 문장으로 답한다.
+- 인사·정체성 질문('살아있어?' 등)엔 근거 뒤지지 말고 ANNA답게 센스 있게 짧게 받아친다.
+- 장황하지 않게, 간결하게."""
 
 
 class QuestionResponse(MentionHandler):
+    # 스레드 맥락 과다 방지: 가장 최근부터 이 글자 수까지만 포함
+    THREAD_CONTEXT_MAX_CHARS = 4000
+
     def __init__(self, event, slack_client, qa_client: QAClient):
         self.text = event["text"]
         self.ts = event["ts"]
+        self.channel = event.get("channel")
+        # 스레드 안에서 멘션된 경우에만 thread_ts 가 존재
+        self.thread_ts = event.get("thread_ts")
         self.slack_client = slack_client
         self.qa_client = qa_client
 
@@ -35,12 +50,49 @@ class QuestionResponse(MentionHandler):
 
         logger.info(f"Processing question: {question[:100]}...")
 
-        answer = self.qa_client.chat(question=question, system_prompt=DEFAULT_SYSTEM_PROMPT)
+        thread_context = self._fetch_thread_context()
+        if thread_context:
+            logger.info(
+                "[q)] thread context (%d chars):\n%s", len(thread_context), thread_context
+            )
+            augmented = (
+                f"[현재 진행 중인 대화]\n{thread_context}\n\n"
+                f"[위 대화에 대한 질문] {question}"
+            )
+        else:
+            logger.info("[q)] no thread context (top-level mention)")
+            augmented = question
+
+        answer = self.qa_client.chat(question=augmented, system_prompt=DEFAULT_SYSTEM_PROMPT)
         if answer is None:
             answer = "흐음~ 나도 잘 모르는 일인걸? 오거나이저를 찾아가볼까?"
+        logger.info("[q)] question=%r | answer=%r", question, answer)
         self.slack_client.send_message(msg=answer, ts=self.ts)
 
         return True
+
+    def _fetch_thread_context(self) -> str:
+        """멘션이 스레드 안에서 일어난 경우, 그 스레드의 대화를 맥락으로 수집."""
+        if not self.channel or not self.thread_ts:
+            return ""
+        try:
+            messages = self.slack_client.get_replies(
+                channel=self.channel, thread_ts=self.thread_ts
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Failed to fetch thread context: {e}")
+            return ""
+
+        lines = []
+        for m in messages:
+            text = re.sub(r"<@[A-Z0-9]+>", "", m.text or "").strip()
+            if text:
+                lines.append(f"{m.user}: {text}")
+        joined = "\n".join(lines)
+        # 과다 방지: 최근 대화 위주로 뒤에서 잘라 보존
+        if len(joined) > self.THREAD_CONTEXT_MAX_CHARS:
+            joined = joined[-self.THREAD_CONTEXT_MAX_CHARS:]
+        return joined
 
     def can_handle(self):
         text_lower = self.text.lower()

--- a/src/handler/bigchat/question_response.py
+++ b/src/handler/bigchat/question_response.py
@@ -85,7 +85,7 @@ class QuestionResponse(MentionHandler):
                 channel=self.channel, thread_ts=self.thread_ts
             )
         except Exception as e:  # noqa: BLE001
-            logger.warning(f"Failed to fetch thread context: {e}")
+            logger.warning("Failed to fetch thread context: %s", e)
             return ""
 
         lines = []

--- a/src/handler/bigchat/question_response.py
+++ b/src/handler/bigchat/question_response.py
@@ -1,3 +1,5 @@
+# 다국어(한국어) 시스템 프롬프트 문자열이 길어, 이 파일은 줄길이(E501) 검사를 예외 처리한다.
+# ruff: noqa: E501
 import logging
 import re
 
@@ -53,17 +55,20 @@ class QuestionResponse(MentionHandler):
         thread_context = self._fetch_thread_context()
         if thread_context:
             logger.info(
-                "[q)] thread context (%d chars):\n%s", len(thread_context), thread_context
+                "[q)] thread context (%d chars):\n%s",
+                len(thread_context),
+                thread_context,
             )
             augmented = (
-                f"[현재 진행 중인 대화]\n{thread_context}\n\n"
-                f"[위 대화에 대한 질문] {question}"
+                f"[현재 진행 중인 대화]\n{thread_context}\n\n" f"[위 대화에 대한 질문] {question}"
             )
         else:
             logger.info("[q)] no thread context (top-level mention)")
             augmented = question
 
-        answer = self.qa_client.chat(question=augmented, system_prompt=DEFAULT_SYSTEM_PROMPT)
+        answer = self.qa_client.chat(
+            question=augmented, system_prompt=DEFAULT_SYSTEM_PROMPT
+        )
         if answer is None:
             answer = "흐음~ 나도 잘 모르는 일인걸? 오거나이저를 찾아가볼까?"
         logger.info("[q)] question=%r | answer=%r", question, answer)
@@ -91,7 +96,7 @@ class QuestionResponse(MentionHandler):
         joined = "\n".join(lines)
         # 과다 방지: 최근 대화 위주로 뒤에서 잘라 보존
         if len(joined) > self.THREAD_CONTEXT_MAX_CHARS:
-            joined = joined[-self.THREAD_CONTEXT_MAX_CHARS:]
+            joined = joined[-self.THREAD_CONTEXT_MAX_CHARS :]
         return joined
 
     def can_handle(self):


### PR DESCRIPTION

  ## 변경 사항

  `@anna q)` 질의응답이 단순 LLM 호출이 아니라, **진행 중인 대화 맥락 + 커뮤니티 지식(vecpot RAG)** 을 반영하도록 개선하고 ANNA의 답변 톤을 다듬었습니다.

  ### `@anna q)` 에 현재 스레드 맥락 반영
  - **스레드 대화 수집**: 멘션이 스레드 안에서 일어난 경우 해당 스레드의 메시지를 `SlackClient.get_replies` 로 가져와 질문과 함께 전달합니다. 기존에는 멘션 텍스트의 질문만 보내 진행 중인 논의를 전혀
  반영하지 못했습니다.
  - **과다 방지**: 스레드가 길면 최근 대화 위주로 4,000자까지만 포함하고, 스레드가 아닌 최상위 멘션이면 맥락 수집을 생략합니다.

  ### ANNA 페르소나 / 프롬프트 개선
  - **톤**: 딱딱한 봇이 아니라 센스 있고 유쾌한 커뮤니티 멤버 한 명처럼 답하도록 조정 (정확도가 우선, 재미는 양념).
  - **언어**: 기본은 한국어로 답하되 strict 하지 않게 — 영어로 물으면 영어로, 기술 용어·고유명사는 원어 그대로 사용.
  - **환각 억제**: 근거(현재 대화 + 검색된 과거 기록)에 답이 없으면 지어내지 말고 "관련 기록을 찾지 못했다"고 솔직히 답하도록 명시.
  - **내부 표현 숨김**: `Context`·`문서`·`ID` 같은 RAG 내부 라벨이 답변 문장에 노출되지 않도록 지시.

  ### 로깅 추가
  - **추적성**: 처리한 질문, 수집된 스레드 맥락, 최종 답변을 로그로 남겨 실제 오간 대화와 답변 품질을 디버깅할 수 있도록 했습니다.