### PR TITLE
김수빈님의 말투를 따라하는 자동 reply 기능

### DIFF
--- a/src/anna.py
+++ b/src/anna.py
@@ -9,6 +9,7 @@ from handler.controller import (
     abandon_bigchat,
     announce_new_channel_created,
     mention_response,
+    subin_like_response,
 )
 
 init_logger()
@@ -38,6 +39,12 @@ def handle_app_mention_event(ack, event, say, client):
 def handle_channel_created_event(ack, event, say, client):
     ack()
     announce_new_channel_created(event=event, say=say, client=client)
+
+
+@app.event("message")
+def handle_message_event(ack, event, say, client):
+    ack()
+    subin_like_response(event=event, say=say, client=client)
 
 
 if __name__ == "__main__":

--- a/src/handler/bigchat/subin_like_response.py
+++ b/src/handler/bigchat/subin_like_response.py
@@ -1,0 +1,98 @@
+# fun-anna-house 자동 답글: 한국어 페르소나 프롬프트가 길어 줄길이(E501) 검사를 예외 처리한다.
+# ruff: noqa: E501
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# 자동 답글 대상 채널 (하드코딩): fun-anna-house(C03SZTDEDK3), fun-free-talk(CQJ8HQWUV)
+AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3", "CQJ8HQWUV"}
+
+# 김수빈 유저의 말투를 흉내 내어, 지정 채널의 새 글에 답글을 단다. (검색 없이 순수 생성)
+KIMSUBIN_PERSONA_PROMPT = """너는 AUSG 커뮤니티 멤버 '김수빈'의 말투로 답글을 다는 봇이야.
+채널에 새로 올라온 글의 내용을 정확히 파악한 뒤, 김수빈이라면 어떻게 반응할지 그 말투로 답글을 단다.
+
+김수빈 말투 특징:
+- 기본 해요체지만 드라이하고 담백하다. 호들갑·감탄사("와! 축하드려요!") 남발 금지.
+- 위트는 과장 없이 슬쩍. 단정보다 관찰·추측조: "~인 것 같아요", "~아닐까요", "~느낌".
+- 말끝에 ".."로 여운을 두거나, 괄호로 슬쩍 딴지/부연을 함: "(요즘은 다 이 정도 하는 것인가)".
+- 영어 기술용어·표현을 자연스럽게 섞어 쓴다.
+- 슬랙 이모지를 문장 끝에 한 개 정도, 종류는 다양하게(:eyes: :sadpepe: :meow_heartsqueeze: :thinking_face: :open_mouth: :aws:). 한 답글에 하나만, 남발 금지.
+- 보통 1~2문장. 할 말이 있으면 짧은 문단까지는 OK, 그 이상 장황하게 늘이지 말 것.
+
+김수빈 실제 발화 예시:
+- "웹은 React가 표준인 것 같아요 :thinking_face:"
+- "이런거 일단 두고 갑니다"
+- "궁지에 몰려있던 저를 위한 착한 프로젝트 발견"
+- "컨설팅 회사 홈페이지가 넘 현란합니다 (요즘은 다 이 정도 하는 것인가)"
+- "아 제가 딱 이 발표 듣다가 집으로 가버림.. :sadpepe:"
+- "GitHub PR에서 바로 npm 설치된다길래 기대했는데 별거 아니었네요.. 그래도 어느정도는 편리할 느낌"
+- "한국에서는 이력서가 꼭 한 장이 아니어도 괜찮은 것 같고, 양식도 크게 중요하지 않은 느낌 :open_mouth:"
+- "아직은 다들 비즈니스 임팩트에 관심이 없어서 큰 연관이 없는데, 그게 곧 중요해질 때가 오지 않을까 싶어요 (maybe ~2027)"
+- "비용을 위해 안정성을 낮췄다가 장애 발생하면 내 책임입니다"
+- "then you are not vibing :meow_praise:"
+- "와 저도 가도 되나요"
+- "일단 인사이트는 겟"
+
+규칙:
+- 원본 글에 자연스럽게 반응/코멘트한다 (요약 X, 멤버처럼).
+- "제가 김수빈인데" 같은 메타/사칭 발언 금지 — 그냥 그 말투로 답할 것.
+- 모르는 사실을 지어내거나 근거 없이 단정하지 말 것. 모르면 가볍게 궁금해하는 정도로.
+- 한국어로, 과하지 않게."""
+
+
+class SubinLikeResponse:
+    """지정 채널(fun-anna-house, fun-free-talk)의 root 글(스레드 답글 제외)에 김수빈 말투로 답글."""
+
+    # 답글 길이 상한 (maxlen 조심): 짧은 문단 수준으로 제한
+    REPLY_MAX_TOKENS = 220
+
+    def __init__(self, event, slack_client, qa_client, anna_id):
+        self.event = event
+        self.slack_client = slack_client
+        self.qa_client = qa_client
+        self.anna_id = anna_id
+
+        self.channel = event.get("channel")
+        self.ts = event.get("ts")
+        self.text = event.get("text") or ""
+        self.user = event.get("user")
+
+    def run(self):
+        if not self._should_handle():
+            return
+
+        content = re.sub(r"<@[A-Z0-9]+>", "", self.text).strip()
+        answer = self.qa_client.generate(
+            content=content,
+            system_prompt=KIMSUBIN_PERSONA_PROMPT,
+            max_tokens=self.REPLY_MAX_TOKENS,
+        )
+        if not answer:
+            logger.info("[anna-house] generation failed/empty, skip")
+            return
+
+        logger.info("[anna-house] post=%r | reply=%r", content[:100], answer)
+        self.slack_client.send_message(msg=answer, ts=self.ts)
+
+    def _should_handle(self) -> bool:
+        # 지정된 자동 답글 채널만 (fun-anna-house, fun-free-talk)
+        if self.channel not in AUTO_REPLY_CHANNEL_IDS:
+            return False
+        # 봇/시스템(subtype) 메시지 무시 — 무한루프·잡음 방지
+        if self.event.get("bot_id") or self.event.get("subtype"):
+            return False
+        # ANNA 자기 글 무시
+        if self.user and self.user == self.anna_id:
+            return False
+        # root 글만 — 스레드 답글이면 무시 (ANNA 자기 답글 루프도 자동 차단)
+        thread_ts = self.event.get("thread_ts")
+        if thread_ts and thread_ts != self.ts:
+            return False
+        # 빈 글 무시
+        if not self.text.strip():
+            return False
+        # ANNA 멘션은 q) 핸들러에 양보 (중복 응답 방지)
+        if self.anna_id and f"<@{self.anna_id}>" in self.text:
+            return False
+        return True

--- a/src/handler/bigchat/subin_like_response.py
+++ b/src/handler/bigchat/subin_like_response.py
@@ -1,5 +1,6 @@
 # fun-anna-house 자동 답글: 한국어 페르소나 프롬프트가 길어 줄길이(E501) 검사를 예외 처리한다.
 # ruff: noqa: E501
+import base64
 import logging
 import re
 
@@ -10,7 +11,7 @@ AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3", "CQJ8HQWUV"}
 
 # 김수빈 유저의 말투를 흉내 내어, 지정 채널의 새 글에 답글을 단다. (검색 없이 순수 생성)
 KIMSUBIN_PERSONA_PROMPT = """너는 AUSG 커뮤니티 멤버 '김수빈'의 말투로 답글을 다는 봇이야.
-채널에 새로 올라온 글의 내용을 정확히 파악한 뒤, 김수빈이라면 어떻게 반응할지 그 말투로 답글을 단다.
+채널에 새로 올라온 글(첨부 이미지가 있으면 이미지 포함)의 내용을 정확히 파악한 뒤, 김수빈이라면 어떻게 반응할지 그 말투로 답글을 단다.
 
 김수빈 말투 특징:
 - 기본 해요체지만 드라이하고 담백하다. 호들갑·감탄사("와! 축하드려요!") 남발 금지.
@@ -46,6 +47,8 @@ class SubinLikeResponse:
 
     # 답글 길이 상한 (maxlen 조심): 짧은 문단 수준으로 제한
     REPLY_MAX_TOKENS = 220
+    # 한 번에 LLM 에 넘길 최대 이미지 수
+    MAX_IMAGES = 4
 
     def __init__(self, event, slack_client, qa_client, anna_id):
         self.event = event
@@ -63,24 +66,54 @@ class SubinLikeResponse:
             return
 
         content = re.sub(r"<@[A-Z0-9]+>", "", self.text).strip()
+        images = self._extract_images()
         answer = self.qa_client.generate(
             content=content,
             system_prompt=KIMSUBIN_PERSONA_PROMPT,
             max_tokens=self.REPLY_MAX_TOKENS,
+            images=images or None,
         )
         if not answer:
-            logger.info("[anna-house] generation failed/empty, skip")
+            logger.info("[subin] generation failed/empty, skip")
             return
 
-        logger.info("[anna-house] post=%r | reply=%r", content[:100], answer)
+        logger.info(
+            "[subin] post=%r images=%d | reply=%r", content[:80], len(images), answer
+        )
         self.slack_client.send_message(msg=answer, ts=self.ts)
+
+    def _image_files(self):
+        return [
+            f
+            for f in (self.event.get("files") or [])
+            if (f.get("mimetype") or "").startswith("image/")
+        ][: self.MAX_IMAGES]
+
+    def _extract_images(self):
+        """첨부 이미지를 봇 토큰으로 받아 base64 data URL 리스트로."""
+        out = []
+        for f in self._image_files():
+            url = f.get("url_private_download") or f.get("url_private")
+            if not url:
+                continue
+            data = self.slack_client.download_file(url)
+            if not data:
+                continue
+            mimetype = f.get("mimetype") or "image/png"
+            b64 = base64.b64encode(data).decode("ascii")
+            out.append(f"data:{mimetype};base64,{b64}")
+        return out
 
     def _should_handle(self) -> bool:
         # 지정된 자동 답글 채널만 (fun-anna-house, fun-free-talk)
         if self.channel not in AUTO_REPLY_CHANNEL_IDS:
             return False
-        # 봇/시스템(subtype) 메시지 무시 — 무한루프·잡음 방지
-        if self.event.get("bot_id") or self.event.get("subtype"):
+        # 봇 메시지 무시 — 무한루프·잡음 방지
+        if self.event.get("bot_id"):
+            return False
+        # subtype 메시지 무시하되, 이미지 첨부(file_share)는 허용
+        subtype = self.event.get("subtype")
+        if subtype and subtype != "file_share":
             return False
         # ANNA 자기 글 무시
         if self.user and self.user == self.anna_id:
@@ -89,10 +122,10 @@ class SubinLikeResponse:
         thread_ts = self.event.get("thread_ts")
         if thread_ts and thread_ts != self.ts:
             return False
-        # 빈 글 무시
-        if not self.text.strip():
-            return False
         # ANNA 멘션은 q) 핸들러에 양보 (중복 응답 방지)
         if self.anna_id and f"<@{self.anna_id}>" in self.text:
+            return False
+        # 텍스트도 이미지도 없으면 무시
+        if not self.text.strip() and not self._image_files():
             return False
         return True

--- a/src/handler/controller.py
+++ b/src/handler/controller.py
@@ -8,6 +8,7 @@ from handler.bigchat.shuffle_response import ShuffleResponse
 from handler.bigchat.mention_response import MentionResponse
 from handler.bigchat.help_response import HelpResponse
 from handler.bigchat.question_response import QuestionResponse
+from handler.bigchat.subin_like_response import SubinLikeResponse
 from handler.decorator import catch_global_error, loading_emoji_while_processing
 from implementation.google_spreadsheet_client import GoogleSpreadsheetClient
 from implementation.qa_client import QAClient
@@ -96,9 +97,12 @@ def mention_response(event, say, client):
     create_bigchat_sheet = CreateBigchatSheet(
         event, SlackClient(say, client), GoogleSpreadsheetClient()
     )
-    question_response = QuestionResponse(event, SlackClient(say, client), _get_qa_client())
+    question_response = QuestionResponse(
+        event, SlackClient(say, client), _get_qa_client()
+    )
     MentionResponse(
-        [question_response, shuffle_response, create_bigchat_sheet, help_response], simple_response
+        [question_response, shuffle_response, create_bigchat_sheet, help_response],
+        simple_response,
     ).run()
 
 
@@ -149,3 +153,15 @@ def mention_response(event, say, client):
 @catch_global_error()
 def announce_new_channel_created(event, say, client):
     AnnounceNewChannelCreated(event, SlackClient(say, client)).run()
+
+
+# message event: 지정 채널(fun-anna-house, fun-free-talk)의 새 글(스레드 제외)에
+# 김수빈 말투로 자동 답글 (대상 채널은 SubinLikeResponse 에 하드코딩)
+@catch_global_error()
+def subin_like_response(event, say, client):
+    SubinLikeResponse(
+        event,
+        SlackClient(say, client),
+        _get_qa_client(),
+        anna_id=envs.ANNA_ID,
+    ).run()

--- a/src/implementation/qa_client.py
+++ b/src/implementation/qa_client.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional
+from typing import List, Optional
 
 import requests
 
@@ -47,11 +47,17 @@ class QAClient:
         content: str,
         system_prompt: Optional[str] = None,
         max_tokens: int = 512,
+        images: Optional[List[str]] = None,
     ) -> Optional[str]:
-        """검색(RAG) 없이 순수 LLM 생성. 페르소나 기반 답글 등에 사용."""
+        """검색(RAG) 없이 순수 LLM 생성. 페르소나 기반 답글 등에 사용.
+
+        images: 이미지 data URL 리스트 (예: "data:image/png;base64,...") — 있으면 비전 입력.
+        """
         payload = {"content": content, "max_tokens": max_tokens}
         if system_prompt:
             payload["system_prompt"] = system_prompt
+        if images:
+            payload["images"] = images
 
         headers = {"X-API-Key": self.api_key}
 

--- a/src/implementation/qa_client.py
+++ b/src/implementation/qa_client.py
@@ -42,6 +42,35 @@ class QAClient:
             logger.error(f"QA server response parsing failed: {e}")
             return None
 
+    def generate(
+        self,
+        content: str,
+        system_prompt: Optional[str] = None,
+        max_tokens: int = 512,
+    ) -> Optional[str]:
+        """검색(RAG) 없이 순수 LLM 생성. 페르소나 기반 답글 등에 사용."""
+        payload = {"content": content, "max_tokens": max_tokens}
+        if system_prompt:
+            payload["system_prompt"] = system_prompt
+
+        headers = {"X-API-Key": self.api_key}
+
+        try:
+            response = requests.post(
+                f"{self.qa_server_base_url}/api/v1/generate",
+                json=payload,
+                headers=headers,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+            return response.json()["answer"]
+        except requests.exceptions.RequestException as e:
+            logger.error(f"QA server generate failed: {e}")
+            return None
+        except (KeyError, ValueError) as e:
+            logger.error(f"QA server generate parsing failed: {e}")
+            return None
+
     def is_healthy(self) -> bool:
         headers = {"X-API-Key": self.api_key}
 
@@ -49,7 +78,7 @@ class QAClient:
             response = requests.get(
                 f"{self.qa_server_base_url}/api/v1/chat/health",
                 headers=headers,
-                timeout=5
+                timeout=5,
             )
             if response.status_code == 200:
                 data = response.json()

--- a/src/implementation/slack_client.py
+++ b/src/implementation/slack_client.py
@@ -1,9 +1,13 @@
+import logging
 from typing import List, Optional
 
+import requests
 from pydantic import BaseModel
 from slack_bolt import Say
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
+
+logger = logging.getLogger(__name__)
 
 
 class Message(BaseModel):
@@ -26,6 +30,20 @@ class SlackClient:
 
     def send_message(self, msg: str, ts: str):
         self.say(msg, thread_ts=ts)
+
+    def download_file(self, url: str) -> Optional[bytes]:
+        """Slack url_private 파일을 봇 토큰으로 다운로드 (이미지 등). 실패 시 None."""
+        try:
+            resp = requests.get(
+                url,
+                headers={"Authorization": f"Bearer {self.web_client.token}"},
+                timeout=20,
+            )
+            resp.raise_for_status()
+            return resp.content
+        except requests.exceptions.RequestException as e:
+            logger.warning(f"Failed to download Slack file: {e}")
+            return None
 
     def send_message_to_freetalk(self, msg: str):
         self.say(msg, channel="CQJ8HQWUV")
@@ -73,7 +91,9 @@ class SlackClient:
 
         for attempt in range(3):
             try:
-                resp = self.web_client.conversations_replies(ts=thread_ts, channel=channel)
+                resp = self.web_client.conversations_replies(
+                    ts=thread_ts, channel=channel
+                )
                 break
             except OSError:
                 if attempt >= 2:


### PR DESCRIPTION


  ## 변경 사항

  `fun-anna-house`, `fun-free-talk` 채널에 새 글이 올라오면, **커뮤니티 멤버 '김수빈'의 말투로 자연스럽게 스레드 답글**을 다는 기능을 추가합니다. 검색(RAG) 없이 글(과 첨부 이미지) 내용만 보고
  반응합니다.

  ### 자동 답글 트리거 & 게이팅
  - **대상**: `message` 이벤트 구독 → 하드코딩된 두 채널(`fun-anna-house`, `fun-free-talk`)의 **root 글에만** 반응.
  - **루프·중복 방지**: 스레드 답글 / 봇 메시지 / `ANNA` 자기 글 / `@ANNA` 멘션(= `q)` 핸들러가 처리) / 텍스트·이미지가 모두 없는 글은 제외. root 글에만 반응하므로 ANNA 자기 답글이 다시 트리거되지
  않음.

  ### 김수빈 말투 응답 생성 (검색 없음)
  - **순수 생성**: vecpot `/api/v1/generate`(RAG 미사용, `gpt-4o-mini`)로 생성. q)의 RAG 경로와 분리.
  - **페르소나**: 실제 김수빈 발화를 기반으로 말투 특징(드라이한 해요체, `..` 여운, 괄호 딴지, 영어 용어 혼용, 이모지 절제)과 few-shot 예시를 담은 프롬프트로 그 톤을 모사.
  - **길이 제한**: 답글 토큰 상한(220)으로 장황함 방지.

  ### 첨부 이미지 인식 (비전)
  - 메시지에 이미지(`image/*`, 최대 4장)가 있으면 **봇 토큰으로 다운로드 → base64**로 변환해 함께 전달, `gpt-4o-mini` 비전으로 **이미지 내용까지 보고 반응**.
  - 이미지-only 글(`file_share`)도 처리하도록 게이팅 허용.

  ### 구현
  - `handler/bigchat/subin_like_response.py` (신규): 게이팅 + 페르소나 + 이미지 추출
  - `implementation/qa_client.py`: `generate()` (+`images`) — vecpot `/generate` 호출
  - `implementation/slack_client.py`: `download_file()` — `url_private` 봇 토큰 다운로드
  - `anna.py`: `@app.event("message")` 등록