### PR TITLE
안나 끄기

### DIFF
--- a/src/handler/bigchat/subin_like_response.py
+++ b/src/handler/bigchat/subin_like_response.py
@@ -7,7 +7,7 @@ import re
 logger = logging.getLogger(__name__)
 
 # 자동 답글 대상 채널 (하드코딩): fun-anna-house(C03SZTDEDK3), fun-free-talk(CQJ8HQWUV)
-AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3"}
+AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3", "CQJ8HQWUV"}
 
 # opt-out 스위치: 글에 이 문구가 있으면 ANNA 가 응답하지 않음 ("안나X" 도 매칭되도록 소문자 비교)
 OPT_OUT_MARKER = "안나x"

--- a/src/handler/bigchat/subin_like_response.py
+++ b/src/handler/bigchat/subin_like_response.py
@@ -7,7 +7,7 @@ import re
 logger = logging.getLogger(__name__)
 
 # 자동 답글 대상 채널 (하드코딩): fun-anna-house(C03SZTDEDK3), fun-free-talk(CQJ8HQWUV)
-AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3", "CQJ8HQWUV"}
+AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3"}
 
 # 김수빈 유저의 말투를 흉내 내어, 지정 채널의 새 글에 답글을 단다. (검색 없이 순수 생성)
 KIMSUBIN_PERSONA_PROMPT = """너는 AUSG 커뮤니티 멤버 '김수빈'의 말투로 답글을 다는 봇이야.

--- a/src/handler/bigchat/subin_like_response.py
+++ b/src/handler/bigchat/subin_like_response.py
@@ -9,6 +9,9 @@ logger = logging.getLogger(__name__)
 # 자동 답글 대상 채널 (하드코딩): fun-anna-house(C03SZTDEDK3), fun-free-talk(CQJ8HQWUV)
 AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3"}
 
+# opt-out 스위치: 글에 이 문구가 있으면 ANNA 가 응답하지 않음 ("안나X" 도 매칭되도록 소문자 비교)
+OPT_OUT_MARKER = "안나x"
+
 # 김수빈 유저의 말투를 흉내 내어, 지정 채널의 새 글에 답글을 단다. (검색 없이 순수 생성)
 KIMSUBIN_PERSONA_PROMPT = """너는 AUSG 커뮤니티 멤버 '김수빈'의 말투로 답글을 다는 봇이야.
 채널에 새로 올라온 글(첨부 이미지가 있으면 이미지 포함)의 내용을 정확히 파악한 뒤, 김수빈이라면 어떻게 반응할지 그 말투로 답글을 단다.
@@ -107,6 +110,9 @@ class SubinLikeResponse:
     def _should_handle(self) -> bool:
         # 지정된 자동 답글 채널만 (fun-anna-house, fun-free-talk)
         if self.channel not in AUTO_REPLY_CHANNEL_IDS:
+            return False
+        # 사용자 opt-out: 글에 "안나x" 가 있으면 응답하지 않음
+        if OPT_OUT_MARKER in self.text.lower():
             return False
         # 봇 메시지 무시 — 무한루프·잡음 방지
         if self.event.get("bot_id"):

--- a/src/handler/bigchat/subin_like_response.py
+++ b/src/handler/bigchat/subin_like_response.py
@@ -7,7 +7,7 @@ import re
 logger = logging.getLogger(__name__)
 
 # 자동 답글 대상 채널 (하드코딩): fun-anna-house(C03SZTDEDK3), fun-free-talk(CQJ8HQWUV)
-AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3", "CQJ8HQWUV"}
+AUTO_REPLY_CHANNEL_IDS = {"C03SZTDEDK3"}
 
 # opt-out 스위치: 글에 이 문구가 있으면 ANNA 가 응답하지 않음 ("안나X" 도 매칭되도록 소문자 비교)
 OPT_OUT_MARKER = "안나x"


### PR DESCRIPTION

  ## 변경 사항

  `fun-anna-house`·`fun-free-talk` 자동 답글에 **글쓴이가 끌 수 있는 opt-out 스위치**를 추가합니다. 자동 답글을 원치 않을 때 글에 `안나x`만 넣으면 해당 글에는 ANNA가 응답하지 않습니다.

  ### `안나x` opt-out 스위치
  - **동작**: 글 내용에 `안나x`가 포함돼 있으면 자동 답글을 달지 않음 (게이팅 단계에서 스킵).
  - **대소문자 무시**: 소문자 비교라 `안나X`도 동일하게 동작.
  - **위치**: `SubinLikeResponse._should_handle()` — 채널 확인 직후에 검사.

  ```python
  OPT_OUT_MARKER = "안나x"
  ...
  if OPT_OUT_MARKER in self.text.lower():   # "안나X" 도 매칭
      return False