### PR TITLE
빅챗 등록 시 캘린더 추가 버튼 제공 (#112)

### DIFF
--- a/src/anna.py
+++ b/src/anna.py
@@ -1,6 +1,7 @@
 import logging
+import re
 
-from flask import Flask, request
+from flask import Flask, Response, abort, request
 from slack_bolt import App
 from slack_bolt.adapter.flask import SlackRequestHandler
 
@@ -13,6 +14,8 @@ from handler.controller import (
     mention_response,
     subin_like_response,
 )
+from implementation.google_spreadsheet_client import GoogleSpreadsheetClient
+from util.bigchat_event import parse_sheet_name, to_ics, verify_ics_token
 
 init_logger()
 
@@ -49,6 +52,12 @@ def handle_message_event(ack, event, say, client):
     subin_like_response(event=event, say=say, client=client)
 
 
+@app.action(re.compile("calendar_.*"))
+def handle_calendar_button(ack):
+    # 링크 버튼은 URL을 여는 것 외에 서버 동작이 없지만, ack하지 않으면 버튼에 ⚠️가 표시된다
+    ack()
+
+
 flask_app = Flask(__name__)
 slack_request_handler = SlackRequestHandler(app)
 
@@ -61,6 +70,34 @@ def slack_events():
 @flask_app.route("/health", methods=["GET"])
 def health():
     return {"status": "ok"}
+
+
+@flask_app.route("/bigchat/<int:worksheet_id>/event.ics", methods=["GET"])
+def bigchat_ics(worksheet_id: int):
+    if not envs.ICS_TOKEN_SECRET:
+        abort(404)
+    if not verify_ics_token(
+        envs.ICS_TOKEN_SECRET, worksheet_id, request.args.get("token", "")
+    ):
+        abort(403)
+
+    try:
+        sheet_name = GoogleSpreadsheetClient().get_worksheet_title(worksheet_id)
+    except Exception as ex:
+        logging.getLogger(__name__).warning(
+            f"Failed to load worksheet {worksheet_id}: {ex}"
+        )
+        abort(404)
+
+    event = parse_sheet_name(sheet_name or "")
+    if not event:
+        abort(404)
+
+    return Response(
+        to_ics(event, uid=f"bigchat-{worksheet_id}@ausg-anna"),
+        mimetype="text/calendar",
+        headers={"Content-Disposition": 'attachment; filename="event.ics"'},
+    )
 
 
 if __name__ == "__main__":

--- a/src/config/env_config.py
+++ b/src/config/env_config.py
@@ -53,5 +53,9 @@ class Settings(BaseSettings):
     QA_SERVER_BASE_URL: str = ""
     QA_API_KEY: str = ""
 
+    # Bigchat calendar buttons (#112)
+    PUBLIC_BASE_URL: str = "https://anna-v2-2023.fly.dev"
+    ICS_TOKEN_SECRET: str = ""  # 비어 있으면 ics 버튼/엔드포인트 비활성화
+
 
 envs = Settings()  # Singleton

--- a/src/handler/bigchat/create_bigchat_sheet.py
+++ b/src/handler/bigchat/create_bigchat_sheet.py
@@ -1,10 +1,14 @@
 from handler.bigchat.mention_handler import MentionHandler
+from util.bigchat_event import parse_sheet_name
+from util.utils import strip_multiline
 
 
 class CreateBigchatSheet(MentionHandler):
     def __init__(self, event, slack_client, gs_client):
         self.text = event["text"]
         self.ts = event["ts"]
+        self.channel = event["channel"]
+        self.user = event["user"]
         self.slack_client = slack_client
         self.gs_client = gs_client
 
@@ -13,8 +17,19 @@ class CreateBigchatSheet(MentionHandler):
             return False
 
         sheet_name = self.text.split("새로운 빅챗", maxsplit=1)[1].split("\n")[0].strip()
-        if not sheet_name:
-            self.slack_client.send_message(msg="시트 이름이 입력되지 않았어. 다시 입력해줘!", ts=self.ts)
+        if not parse_sheet_name(sheet_name):
+            self.slack_client.send_message_only_visible_to_user(
+                msg=strip_multiline(
+                    f"""
+                    <@{self.user}> 형식이 올바르지 않아서 빅챗을 만들지 않았어. 아래 형식으로 다시 입력해줘!
+                    `새로운 빅챗 <이름> yy-MM-DD HH:mm~HH:mm`
+                    예) `새로운 빅챗 AI 밋업 26-08-20 19:00~21:00`
+                    (실제 존재하는 날짜/시각이어야 하고, 종료 시각은 시작보다 늦어야 해!)"""
+                ),
+                channel=self.channel,
+                ts=self.ts,
+                user_id=self.user,
+            )
             return False
 
         worksheet_id = self.gs_client.create_bigchat_sheet(sheet_name)

--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -1,9 +1,14 @@
-from typing import List
+import logging
 import re
+from typing import List, Optional
 
+from config.env_config import envs
 from implementation.member_finder import MemberNotFound, MemberLackInfo
 from implementation.slack_client import Message
+from util.bigchat_event import parse_sheet_name, to_gcal_link, ics_token
 from util.utils import strip_multiline
+
+logger = logging.getLogger(__name__)
 
 SPREADSHEET_PAT = re.compile(
     r"https://docs.google.com/spreadsheets/d/.*/edit#gid=(\d*)"
@@ -29,6 +34,51 @@ class JoinBigchat:
             if pat is not None and len(pat.groups()) > 0:
                 return int(pat.groups()[0])
         return None
+
+    def _build_calendar_blocks(
+        self, msg: str, worksheet_id: int
+    ) -> Optional[List[dict]]:
+        """시트 이름에서 이벤트 정보를 파싱해 캘린더 버튼 블록을 만든다. 구형식 시트 등 파싱 불가면 None."""
+        try:
+            sheet_name = self.gs_client.get_worksheet_title(worksheet_id)
+            event = parse_sheet_name(sheet_name)
+        except Exception as ex:
+            logger.warning(f"Failed to build calendar buttons: {ex}")
+            return None
+        if not event:
+            return None
+
+        buttons = [
+            {
+                "type": "button",
+                "action_id": "calendar_gcal",
+                "text": {
+                    "type": "plain_text",
+                    "text": "📅 Google Calendar에 추가",
+                    "emoji": True,
+                },
+                "url": to_gcal_link(event),
+            }
+        ]
+        if envs.ICS_TOKEN_SECRET:
+            token = ics_token(envs.ICS_TOKEN_SECRET, worksheet_id)
+            buttons.append(
+                {
+                    "type": "button",
+                    "action_id": "calendar_ics",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "📥 .ics 다운로드",
+                        "emoji": True,
+                    },
+                    "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/event.ics?token={token}",
+                }
+            )
+
+        return [
+            {"type": "section", "text": {"type": "mrkdwn", "text": msg}},
+            {"type": "actions", "elements": buttons},
+        ]
 
     def run(self):
         if self.type != "reaction_added" or self.reaction != self.target_emoji:
@@ -58,18 +108,20 @@ class JoinBigchat:
         self.gs_client.append_row(worksheet_id, member.transform_for_spreadsheet())
 
         self.slack_client.send_message(msg=f"<@{self.user}>, 등록 완료!", ts=self.ts)
+        msg = strip_multiline(
+            f"""
+            <@{self.user}> 네 신청 정보를 아래와 같이 등록했어. 바뀐 부분이 있다면 운영진에게 DM으로 알려줘!
+            ```
+            이름(영문): {member.kor_name}({member.eng_name})
+            핸드폰: {member.phone}
+            이메일: {member.email}
+            학교/회사: {member.school_name_or_company_name}
+            ```
+            (참고로 이 메시지는 너만 볼 수 있어!)"""
+        )
         self.slack_client.send_message_only_visible_to_user(
-            msg=strip_multiline(
-                f"""
-                <@{self.user}> 네 신청 정보를 아래와 같이 등록했어. 바뀐 부분이 있다면 운영진에게 DM으로 알려줘!
-                ```
-                이름(영문): {member.kor_name}({member.eng_name})
-                핸드폰: {member.phone}
-                이메일: {member.email}
-                학교/회사: {member.school_name_or_company_name}
-                ```
-                (참고로 이 메시지는 너만 볼 수 있어!)"""
-            ),
+            msg=msg,
+            blocks=self._build_calendar_blocks(msg, worksheet_id),
             channel=self.channel,
             ts=self.ts,
             user_id=self.user,

--- a/src/implementation/google_spreadsheet_client.py
+++ b/src/implementation/google_spreadsheet_client.py
@@ -78,6 +78,10 @@ class GoogleSpreadsheetClient:
         worksheet = self._get_worksheet(worksheet_id)
         return worksheet.get_values(cell_range)
 
+    @with_retry()
+    def get_worksheet_title(self, worksheet_id: int) -> str:
+        return self._get_worksheet(worksheet_id).title
+
     def get_url(self, worksheet_id: int) -> str:
         return f"https://docs.google.com/spreadsheets/d/{self.spreadsheet_id}/edit#gid={str(worksheet_id)}"
 

--- a/src/implementation/slack_client.py
+++ b/src/implementation/slack_client.py
@@ -49,10 +49,15 @@ class SlackClient:
         self.say(msg, channel="CQJ8HQWUV")
 
     def send_message_only_visible_to_user(
-        self, msg: str, user_id: str, channel: str, ts: Optional[str] = None
+        self,
+        msg: str,
+        user_id: str,
+        channel: str,
+        ts: Optional[str] = None,
+        blocks: Optional[List[dict]] = None,
     ):
         self.web_client.chat_postEphemeral(
-            text=msg, channel=channel, user=user_id, thread_ts=ts
+            text=msg, blocks=blocks, channel=channel, user=user_id, thread_ts=ts
         )
 
     @staticmethod

--- a/src/util/bigchat_event.py
+++ b/src/util/bigchat_event.py
@@ -1,0 +1,105 @@
+import hashlib
+import hmac
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import urlencode
+
+from dateutil.tz import gettz
+
+KST = gettz("Asia/Seoul")
+
+# 빅챗 시트 이름이 곧 이벤트 정보 저장소다: "<name> yy-MM-DD HH:mm~HH:mm"
+# e.g. "AI 밋업 26-08-20 19:00~21:00"
+SHEET_NAME_PAT = re.compile(
+    r"^(?P<name>.+) (?P<date>\d{2}-\d{2}-\d{2}) (?P<start>\d{2}:\d{2})~(?P<end>\d{2}:\d{2})$"
+)
+
+
+@dataclass
+class BigchatEvent:
+    name: str
+    start: datetime  # tz-aware (KST)
+    end: datetime  # tz-aware (KST)
+
+
+def parse_sheet_name(sheet_name: str) -> Optional[BigchatEvent]:
+    """포맷 불일치, 존재하지 않는 날짜/시각, 종료가 시작보다 빠르거나 같으면 None (보정 없음)."""
+    match = SHEET_NAME_PAT.match(sheet_name.strip())
+    if not match:
+        return None
+
+    try:
+        start = datetime.strptime(
+            f"{match['date']} {match['start']}", "%y-%m-%d %H:%M"
+        ).replace(tzinfo=KST)
+        end = datetime.strptime(
+            f"{match['date']} {match['end']}", "%y-%m-%d %H:%M"
+        ).replace(tzinfo=KST)
+    except ValueError:
+        return None
+
+    if end <= start:
+        return None
+
+    return BigchatEvent(name=match["name"].strip(), start=start, end=end)
+
+
+def to_gcal_link(event: BigchatEvent) -> str:
+    params = urlencode(
+        {
+            "action": "TEMPLATE",
+            "text": event.name,
+            "dates": f"{_fmt_local(event.start)}/{_fmt_local(event.end)}",
+            "ctz": "Asia/Seoul",
+        }
+    )
+    return f"https://calendar.google.com/calendar/render?{params}"
+
+
+def to_ics(event: BigchatEvent, uid: str) -> str:
+    # KST는 DST가 없으므로 UTC로 변환해 VTIMEZONE 블록을 생략한다
+    return "\r\n".join(
+        [
+            "BEGIN:VCALENDAR",
+            "VERSION:2.0",
+            "PRODID:-//AUSG//anna//KO",
+            "BEGIN:VEVENT",
+            f"UID:{uid}",
+            f"DTSTAMP:{_fmt_utc(datetime.now(tz=timezone.utc))}",
+            f"DTSTART:{_fmt_utc(event.start)}",
+            f"DTEND:{_fmt_utc(event.end)}",
+            f"SUMMARY:{_escape_ics_text(event.name)}",
+            "END:VEVENT",
+            "END:VCALENDAR",
+            "",
+        ]
+    )
+
+
+def ics_token(secret: str, worksheet_id: int) -> str:
+    return hmac.new(
+        secret.encode(), str(worksheet_id).encode(), hashlib.sha256
+    ).hexdigest()
+
+
+def verify_ics_token(secret: str, worksheet_id: int, token: str) -> bool:
+    return hmac.compare_digest(ics_token(secret, worksheet_id), token)
+
+
+def _fmt_local(dt: datetime) -> str:
+    return dt.strftime("%Y%m%dT%H%M%S")
+
+
+def _fmt_utc(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _escape_ics_text(text: str) -> str:
+    return (
+        text.replace("\\", "\\\\")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+        .replace("\n", "\\n")
+    )

--- a/test/config/test_env_config.py
+++ b/test/config/test_env_config.py
@@ -3,6 +3,7 @@ import unittest
 from importlib import reload
 from config import env_config
 
+
 class TestEnvConfig(unittest.TestCase):
     def test_init_envs(self):
         os.environ["LOGLEVEL"] = "TEST_VALUE"

--- a/test/handler/bigchat/sample_data.py
+++ b/test/handler/bigchat/sample_data.py
@@ -1,90 +1,80 @@
 def create_sample_app_mention_event(msg):
     return {
-        'client_msg_id': '8fb50d48-f93d-4cca-b9ca-6965479e9a93',
-        'type': 'app_mention',
-        'text': msg,
-        'user': 'UQJ8HQJG5',
-        'ts': '1689403771.805849',
-        'blocks': [],  # not used and too long, so skipped
-        'team': 'TQLEG4B38',
-        'thread_ts': '1689403100.222939',
-        'parent_user_id': 'UQJ8HQJG5',
-        'channel': 'C03SZTDEDK3',
-        'event_ts': '1689403771.805849'
+        "client_msg_id": "8fb50d48-f93d-4cca-b9ca-6965479e9a93",
+        "type": "app_mention",
+        "text": msg,
+        "user": "UQJ8HQJG5",
+        "ts": "1689403771.805849",
+        "blocks": [],  # not used and too long, so skipped
+        "team": "TQLEG4B38",
+        "thread_ts": "1689403100.222939",
+        "parent_user_id": "UQJ8HQJG5",
+        "channel": "C03SZTDEDK3",
+        "event_ts": "1689403771.805849",
     }
 
 
 def create_sample_reaction_added_event(emoji_name):
     return {
-        'type': 'reaction_added',
-        'user': 'UQJ8HQJG5',
-        'reaction': emoji_name,
-        'item': {
-            'type': 'message',
-            'channel': 'C03SZTDEDK3',
-            'ts': '1688801145.307229'
+        "type": "reaction_added",
+        "user": "UQJ8HQJG5",
+        "reaction": emoji_name,
+        "item": {
+            "type": "message",
+            "channel": "C03SZTDEDK3",
+            "ts": "1688801145.307229",
         },
-        'item_user': "U01BN035Y6L",
-        'event_ts': '1688833113.003600'
+        "item_user": "U01BN035Y6L",
+        "event_ts": "1688833113.003600",
     }
 
 
 def create_sample_reaction_removed_event(emoji_name):
     return {
-        'type': 'reaction_removed',
-        'user': 'UQJ8HQJG5',
-        'reaction': emoji_name,
-        'item': {
-            'type': 'message',
-            'channel': 'C03SZTDEDK3',
-            'ts': '1688801145.307229'
+        "type": "reaction_removed",
+        "user": "UQJ8HQJG5",
+        "reaction": emoji_name,
+        "item": {
+            "type": "message",
+            "channel": "C03SZTDEDK3",
+            "ts": "1688801145.307229",
         },
-        'item_user': "U01BN035Y6L",
-        'event_ts': '1688833113.003600'
+        "item_user": "U01BN035Y6L",
+        "event_ts": "1688833113.003600",
     }
 
 
 def create_sample_channel_created_event(channel_id):
     return {
-        'type': 'channel_created',
-        'channel': {
-            'id': channel_id,
-            'name': 'test-create-channel-2',
-            'is_channel': True,
-            'is_group': False,
-            'is_im': False,
-            'is_mpim': False,
-            'is_private': False,
-            'created': 1721484974,
-            'is_archived': False,
-            'is_general': False,
-            'unlinked': 0,
-            'name_normalized': 'test-create-channel-2',
-            'is_shared': False,
-            'is_frozen': False,
-            'is_org_shared': False,
-            'is_pending_ext_shared': False,
-            'pending_shared': [],
-            'context_team_id': 'TQLEG4B38',
-            'updated': 1721484974161,
-            'parent_conversation': None,
-            'creator': 'UQJ8HQJG5',
-            'is_ext_shared': False,
-            'shared_team_ids': [
-                'TQLEG4B38'
-            ],
-            'pending_connected_team_ids': [],
-            'topic': {
-                'value': '',
-                'creator': '',
-                'last_set': 0
-            },
-            'purpose': {
-                'value': '',
-                'creator': '',
-                'last_set': 0
-            },
-            'previous_names': []
+        "type": "channel_created",
+        "channel": {
+            "id": channel_id,
+            "name": "test-create-channel-2",
+            "is_channel": True,
+            "is_group": False,
+            "is_im": False,
+            "is_mpim": False,
+            "is_private": False,
+            "created": 1721484974,
+            "is_archived": False,
+            "is_general": False,
+            "unlinked": 0,
+            "name_normalized": "test-create-channel-2",
+            "is_shared": False,
+            "is_frozen": False,
+            "is_org_shared": False,
+            "is_pending_ext_shared": False,
+            "pending_shared": [],
+            "context_team_id": "TQLEG4B38",
+            "updated": 1721484974161,
+            "parent_conversation": None,
+            "creator": "UQJ8HQJG5",
+            "is_ext_shared": False,
+            "shared_team_ids": ["TQLEG4B38"],
+            "pending_connected_team_ids": [],
+            "topic": {"value": "", "creator": "", "last_set": 0},
+            "purpose": {"value": "", "creator": "", "last_set": 0},
+            "previous_names": [],
         },
-        'event_ts': '1721484974.006000'
+        "event_ts": "1721484974.006000",
     }

--- a/test/handler/bigchat/test_abandon_bigchat.py
+++ b/test/handler/bigchat/test_abandon_bigchat.py
@@ -12,16 +12,22 @@ class TestAbandonBigchat(unittest.TestCase):
     def test_run(self):
         event = create_sample_reaction_removed_event("gogo")
         mock_slack_client = MagicMock()
-        mock_slack_client.get_replies.return_value = [Message(ts=event["item"]["ts"],
-                                                              thread_ts="1689429129.825319",
-                                                              channel="C03SZTDEDK3",
-                                                              user="U01BN035Y6L",
-                                                              text="새로운 빅챗을 모집합니다!"),
-                                                      Message(ts=event["item"]["ts"],
-                                                              thread_ts="1689429129.825319",
-                                                              channel="C03SZTDEDK3",
-                                                              user="U01BN035Y6L",
-                                                              text="새로운 빅챗, 등록 완료! <https://docs.google.com/spreadsheets/d/1FtKRO4gmlVg-Si0_CHt-tkpVd3LDTXdsoZ0u98MYd0k/edit#gid=161837744|구글스프레드 시트>")]
+        mock_slack_client.get_replies.return_value = [
+            Message(
+                ts=event["item"]["ts"],
+                thread_ts="1689429129.825319",
+                channel="C03SZTDEDK3",
+                user="U01BN035Y6L",
+                text="새로운 빅챗을 모집합니다!",
+            ),
+            Message(
+                ts=event["item"]["ts"],
+                thread_ts="1689429129.825319",
+                channel="C03SZTDEDK3",
+                user="U01BN035Y6L",
+                text="새로운 빅챗, 등록 완료! <https://docs.google.com/spreadsheets/d/1FtKRO4gmlVg-Si0_CHt-tkpVd3LDTXdsoZ0u98MYd0k/edit#gid=161837744|구글스프레드 시트>",
+            ),
+        ]
         mock_member_manager = MagicMock()
         mock_member_manager.find.return_value = Member(
             kor_name="문성혁",
@@ -31,7 +37,14 @@ class TestAbandonBigchat(unittest.TestCase):
             school_name_or_company_name="school_name_or_company_name",
         )
         mock_gs_client = MagicMock()
-        sut = AbandonBigchat(event, "U01BN035Y6L", "gogo", mock_slack_client, mock_member_manager, mock_gs_client)
+        sut = AbandonBigchat(
+            event,
+            "U01BN035Y6L",
+            "gogo",
+            mock_slack_client,
+            mock_member_manager,
+            mock_gs_client,
+        )
 
         result = sut.run()
 
@@ -40,4 +53,9 @@ class TestAbandonBigchat(unittest.TestCase):
         mock_gs_client.delete_row.assert_called_once()
         mock_slack_client.send_message_only_visible_to_user.assert_called_once()
         assert result is True
-        assert "등록을 취소했어." in mock_slack_client.send_message_only_visible_to_user.call_args.kwargs["msg"]
+        assert (
+            "등록을 취소했어."
+            in mock_slack_client.send_message_only_visible_to_user.call_args.kwargs[
+                "msg"
+            ]
+        )

--- a/test/handler/bigchat/test_announce_new_channel_created.py
+++ b/test/handler/bigchat/test_announce_new_channel_created.py
@@ -15,4 +15,7 @@ class TestAnnounceNewChannelCreated(unittest.TestCase):
 
         mock_slack_client.send_message_to_freetalk.assert_called_once()
         assert result is True
-        assert mock_slack_client.send_message_to_freetalk.call_args.kwargs["msg"] == '새로운 채널이 만들어졌어! <#C1234567890>'
+        assert (
+            mock_slack_client.send_message_to_freetalk.call_args.kwargs["msg"]
+            == "새로운 채널이 만들어졌어! <#C1234567890>"
+        )

--- a/test/handler/bigchat/test_create_bigchat_sheet.py
+++ b/test/handler/bigchat/test_create_bigchat_sheet.py
@@ -7,18 +7,24 @@ from test.handler.bigchat.sample_data import create_sample_app_mention_event
 
 class TestCreateBigchatSheet(unittest.TestCase):
     def test_run(self):
-        event = create_sample_app_mention_event("<@U01BN035Y6L> 새로운 빅챗 빅챗 23-07-31")
+        event = create_sample_app_mention_event(
+            "<@U01BN035Y6L> 새로운 빅챗 AI 밋업 26-08-20 19:00~21:00"
+        )
         mock_slack_client = MagicMock()
         mock_gs_client = MagicMock()
         sut = CreateBigchatSheet(event, mock_slack_client, mock_gs_client)
 
         result = sut.handle_mention()
 
-        mock_gs_client.create_bigchat_sheet.assert_called_once()
+        mock_gs_client.create_bigchat_sheet.assert_called_once_with(
+            "AI 밋업 26-08-20 19:00~21:00"
+        )
         mock_gs_client.get_url.assert_called_once()
         mock_slack_client.send_message.assert_called_once()
         assert result is True
-        assert "새로운 빅챗, 등록 완료!" in mock_slack_client.send_message.call_args.kwargs["msg"]
+        assert (
+            "새로운 빅챗, 등록 완료!" in mock_slack_client.send_message.call_args.kwargs["msg"]
+        )
 
     def test_not_run_by_command_notfound(self):
         event = create_sample_app_mention_event("<@U01BN035Y6L>빅챗 23-07-31")
@@ -32,15 +38,27 @@ class TestCreateBigchatSheet(unittest.TestCase):
         mock_slack_client.assert_not_called()
         assert result is False
 
-    def test_not_run_by_sheet_name_notfound(self):
-        event = create_sample_app_mention_event("<@U01BN035Y6L> 새로운 빅챗 \n\n\n\n")
-        mock_slack_client = MagicMock()
-        mock_gs_client = MagicMock()
-        sut = CreateBigchatSheet(event, mock_slack_client, mock_gs_client)
+    def test_rejected_by_invalid_format(self):
+        for text in [
+            "<@U01BN035Y6L> 새로운 빅챗 \n\n\n\n",  # 이름 없음
+            "<@U01BN035Y6L> 새로운 빅챗 빅챗 23-07-31",  # 시간 없음 (구형식)
+            "<@U01BN035Y6L> 새로운 빅챗 AI 밋업 26-02-30 19:00~21:00",  # 존재하지 않는 날짜
+            "<@U01BN035Y6L> 새로운 빅챗 AI 밋업 26-08-20 21:00~19:00",  # 종료가 시작보다 빠름
+        ]:
+            event = create_sample_app_mention_event(text)
+            mock_slack_client = MagicMock()
+            mock_gs_client = MagicMock()
+            sut = CreateBigchatSheet(event, mock_slack_client, mock_gs_client)
 
-        result = sut.handle_mention()
+            result = sut.handle_mention()
 
-        mock_gs_client.assert_not_called()
-        mock_slack_client.send_message.assert_called_once()
-        assert result is False
-        assert "시트 이름이 입력되지 않았어. 다시 입력해줘!" in mock_slack_client.send_message.call_args.kwargs["msg"]
+            mock_gs_client.create_bigchat_sheet.assert_not_called()
+            mock_slack_client.send_message.assert_not_called()
+            mock_slack_client.send_message_only_visible_to_user.assert_called_once()
+            assert result is False
+            assert (
+                "형식이 올바르지 않아서 빅챗을 만들지 않았어"
+                in mock_slack_client.send_message_only_visible_to_user.call_args.kwargs[
+                    "msg"
+                ]
+            )

--- a/test/handler/bigchat/test_help_response.py
+++ b/test/handler/bigchat/test_help_response.py
@@ -16,7 +16,9 @@ class TestHelpResponse(unittest.TestCase):
 
         mock_slack_client.send_message.assert_called_once()
         assert result is True
-        assert mock_slack_client.send_message.call_args.kwargs["msg"].startswith("나를 멘션했을 때, 사용할 수 있는 명령어야")
+        assert mock_slack_client.send_message.call_args.kwargs["msg"].startswith(
+            "나를 멘션했을 때, 사용할 수 있는 명령어야"
+        )
 
     def test_run_by_english(self):
         event = create_sample_app_mention_event("<@U01BN035Y6L> help!")
@@ -27,4 +29,6 @@ class TestHelpResponse(unittest.TestCase):
 
         mock_slack_client.send_message.assert_called_once()
         assert result is True
-        assert mock_slack_client.send_message.call_args.kwargs["msg"].startswith("나를 멘션했을 때, 사용할 수 있는 명령어야")
+        assert mock_slack_client.send_message.call_args.kwargs["msg"].startswith(
+            "나를 멘션했을 때, 사용할 수 있는 명령어야"
+        )

--- a/test/handler/bigchat/test_join_bigchat.py
+++ b/test/handler/bigchat/test_join_bigchat.py
@@ -57,6 +57,44 @@ class TestJoinBigchat(unittest.TestCase):
         )
         assert result is True
 
+    def test_run_with_old_format_sheet_registers_without_buttons(self):
+        """구형식 시트여도 참가 신청은 그대로 성공하고, 캘린더 버튼만 생략된다."""
+        event = create_sample_reaction_added_event("gogo")
+        mock_slack_client = MagicMock()
+        mock_slack_client.get_replies.return_value = [
+            Message(
+                ts=event["item"]["ts"],
+                thread_ts="1689429129.825319",
+                channel="C03SZTDEDK3",
+                user="U01BN035Y6L",
+                text="새로운 빅챗, 등록 완료! <https://docs.google.com/spreadsheets/d/1FtKRO4gmlVg-Si0_CHt-tkpVd3LDTXdsoZ0u98MYd0k/edit#gid=161837744|구글스프레드 시트>",
+            ),
+        ]
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_worksheet_title.return_value = "빅챗 23-07-31"  # 구형식
+        mock_member_manager = MagicMock()
+        mock_member_manager.find.return_value = Member(
+            kor_name="문성혁",
+            eng_name="Moon Seonghyeok",
+            email="email",
+            phone="phone",
+            school_name_or_company_name="school_name_or_company_name",
+        )
+        sut = JoinBigchat(
+            event, "gogo", mock_slack_client, mock_gs_client, mock_member_manager
+        )
+
+        result = sut.run()
+
+        mock_gs_client.append_row.assert_called_once()
+        assert result is True
+        assert (
+            mock_slack_client.send_message_only_visible_to_user.call_args.kwargs[
+                "blocks"
+            ]
+            is None
+        )
+
     def test_build_calendar_blocks_with_new_format_sheet(self):
         event = create_sample_reaction_added_event("gogo")
         mock_gs_client = MagicMock()

--- a/test/handler/bigchat/test_join_bigchat.py
+++ b/test/handler/bigchat/test_join_bigchat.py
@@ -12,16 +12,22 @@ class TestJoinBigchat(unittest.TestCase):
     def test_run(self):
         event = create_sample_reaction_added_event("gogo")
         mock_slack_client = MagicMock()
-        mock_slack_client.get_replies.return_value = [Message(ts=event["item"]["ts"],
-                                                              thread_ts="1689429129.825319",
-                                                              channel="C03SZTDEDK3",
-                                                              user="U01BN035Y6L",
-                                                              text="새로운 빅챗을 모집합니다!"),
-                                                      Message(ts=event["item"]["ts"],
-                                                              thread_ts="1689429129.825319",
-                                                              channel="C03SZTDEDK3",
-                                                              user="U01BN035Y6L",
-                                                              text="새로운 빅챗, 등록 완료! <https://docs.google.com/spreadsheets/d/1FtKRO4gmlVg-Si0_CHt-tkpVd3LDTXdsoZ0u98MYd0k/edit#gid=161837744|구글스프레드 시트>")]
+        mock_slack_client.get_replies.return_value = [
+            Message(
+                ts=event["item"]["ts"],
+                thread_ts="1689429129.825319",
+                channel="C03SZTDEDK3",
+                user="U01BN035Y6L",
+                text="새로운 빅챗을 모집합니다!",
+            ),
+            Message(
+                ts=event["item"]["ts"],
+                thread_ts="1689429129.825319",
+                channel="C03SZTDEDK3",
+                user="U01BN035Y6L",
+                text="새로운 빅챗, 등록 완료! <https://docs.google.com/spreadsheets/d/1FtKRO4gmlVg-Si0_CHt-tkpVd3LDTXdsoZ0u98MYd0k/edit#gid=161837744|구글스프레드 시트>",
+            ),
+        ]
         mock_gs_client = MagicMock()
         mock_member_manager = MagicMock()
         mock_member_manager.find.return_value = Member(
@@ -31,7 +37,9 @@ class TestJoinBigchat(unittest.TestCase):
             phone="phone",
             school_name_or_company_name="school_name_or_company_name",
         )
-        sut = JoinBigchat(event, "gogo", mock_slack_client, mock_gs_client, mock_member_manager)
+        sut = JoinBigchat(
+            event, "gogo", mock_slack_client, mock_gs_client, mock_member_manager
+        )
 
         result = sut.run()
 
@@ -41,6 +49,37 @@ class TestJoinBigchat(unittest.TestCase):
         mock_slack_client.send_message.assert_called_once()
         mock_slack_client.send_message_only_visible_to_user.assert_called_once()
         assert "등록 완료!" in mock_slack_client.send_message.call_args.kwargs["msg"]
-        assert "네 신청 정보를 아래와 같이 등록했어. 바뀐 부분이 있다면 운영진에게 DM으로 알려줘!" in \
-               mock_slack_client.send_message_only_visible_to_user.call_args.kwargs["msg"]
+        assert (
+            "네 신청 정보를 아래와 같이 등록했어. 바뀐 부분이 있다면 운영진에게 DM으로 알려줘!"
+            in mock_slack_client.send_message_only_visible_to_user.call_args.kwargs[
+                "msg"
+            ]
+        )
         assert result is True
+
+    def test_build_calendar_blocks_with_new_format_sheet(self):
+        event = create_sample_reaction_added_event("gogo")
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_worksheet_title.return_value = "AI 밋업 26-08-20 19:00~21:00"
+        sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
+
+        blocks = sut._build_calendar_blocks("등록했어", 161837744)
+
+        assert blocks is not None
+        buttons = blocks[1]["elements"]
+        assert buttons[0]["action_id"] == "calendar_gcal"
+        assert buttons[0]["url"].startswith(
+            "https://calendar.google.com/calendar/render?"
+        )
+        # ICS_TOKEN_SECRET 미설정(기본값) 상태에서는 ics 버튼이 생기지 않는다
+        assert all(b["action_id"] != "calendar_ics" for b in buttons)
+
+    def test_build_calendar_blocks_with_old_format_sheet(self):
+        event = create_sample_reaction_added_event("gogo")
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_worksheet_title.return_value = "빅챗 23-07-31"
+        sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
+
+        blocks = sut._build_calendar_blocks("등록했어", 161837744)
+
+        assert blocks is None

--- a/test/handler/bigchat/test_mention_response.py
+++ b/test/handler/bigchat/test_mention_response.py
@@ -20,7 +20,10 @@ class TestMentionResponse(unittest.TestCase):
 
         mock_slack_client.send_message.assert_called_once()
         assert result is True
-        assert mock_slack_client.send_message.call_args.kwargs["msg"] in ["여기있어!\n<@Uabc> <@Udef>", "여기있어!\n<@Udef> <@Uabc>"]
+        assert mock_slack_client.send_message.call_args.kwargs["msg"] in [
+            "여기있어!\n<@Uabc> <@Udef>",
+            "여기있어!\n<@Udef> <@Uabc>",
+        ]
 
     def test_run_by_unaccepted_keyword_by_fallback(self):
         event = create_sample_app_mention_event("<@U01BN035Y6L>")
@@ -32,4 +35,7 @@ class TestMentionResponse(unittest.TestCase):
         result = sut.run()
 
         assert result is True
-        assert mock_slack_client.send_message.call_args.kwargs["msg"] == "앗, 잘못입력한 것 같아.\n나를 멘션하면서 help를 한 번 입력해봐!"
+        assert (
+            mock_slack_client.send_message.call_args.kwargs["msg"]
+            == "앗, 잘못입력한 것 같아.\n나를 멘션하면서 help를 한 번 입력해봐!"
+        )

--- a/test/handler/bigchat/test_shuffle_response.py
+++ b/test/handler/bigchat/test_shuffle_response.py
@@ -16,14 +16,22 @@ class TestShuffleResponse(unittest.TestCase):
 
         mock_slack_client.send_message.assert_called_once()
         assert result is True
-        assert mock_slack_client.send_message.call_args.kwargs["msg"] in ["여기있어!\n<@Uabc> <@Udef>", "여기있어!\n<@Udef> <@Uabc>"]
+        assert mock_slack_client.send_message.call_args.kwargs["msg"] in [
+            "여기있어!\n<@Uabc> <@Udef>",
+            "여기있어!\n<@Udef> <@Uabc>",
+        ]
 
     def test_run_by_english(self):
-        event = create_sample_app_mention_event("<@U01BN035Y6L> shuffle <@Uabc> <@Udef>")
+        event = create_sample_app_mention_event(
+            "<@U01BN035Y6L> shuffle <@Uabc> <@Udef>"
+        )
         mock_slack_client = MagicMock()
         sut = ShuffleResponse(event, mock_slack_client)
 
         result = sut.handle_mention()
 
         assert result is True
-        assert mock_slack_client.send_message.call_args.kwargs["msg"] in ["여기있어!\n<@Uabc> <@Udef>", "여기있어!\n<@Udef> <@Uabc>"]
+        assert mock_slack_client.send_message.call_args.kwargs["msg"] in [
+            "여기있어!\n<@Uabc> <@Udef>",
+            "여기있어!\n<@Udef> <@Uabc>",
+        ]

--- a/test/handler/bigchat/test_simple_response.py
+++ b/test/handler/bigchat/test_simple_response.py
@@ -16,7 +16,10 @@ class TestSimpleResponse(unittest.TestCase):
 
         mock_slack_client.send_message.assert_called_once()
         assert result is True
-        assert mock_slack_client.send_message.call_args.kwargs["msg"] == "앗, 잘못입력한 것 같아.\n나를 멘션하면서 help를 한 번 입력해봐!"
+        assert (
+            mock_slack_client.send_message.call_args.kwargs["msg"]
+            == "앗, 잘못입력한 것 같아.\n나를 멘션하면서 help를 한 번 입력해봐!"
+        )
 
     def test_run_by_text_not_empty(self):
         event = create_sample_app_mention_event("<@U01BN035Y6L> 안녕?")
@@ -27,4 +30,7 @@ class TestSimpleResponse(unittest.TestCase):
 
         mock_slack_client.send_message.assert_called_once()
         assert result is True
-        assert mock_slack_client.send_message.call_args.kwargs["msg"] == "앗, 잘못입력한 것 같아.\n나를 멘션하면서 help를 한 번 입력해봐!"
+        assert (
+            mock_slack_client.send_message.call_args.kwargs["msg"]
+            == "앗, 잘못입력한 것 같아.\n나를 멘션하면서 help를 한 번 입력해봐!"
+        )

--- a/test/handler/test_decorator.py
+++ b/test/handler/test_decorator.py
@@ -7,17 +7,35 @@ from handler.decorator import loading_emoji_while_processing
 class TestDecorator(unittest.TestCase):
     def test_loading_emoji_while_processing_add_and_remove_emoji(self):
         """
-            function 동작 이전에 loading 이모지를 추가하고
-            function 동작이 마무리되면 loading 이모지를 제거해야만 함.
+        function 동작 이전에 loading 이모지를 추가하고
+        function 동작이 마무리되면 loading 이모지를 제거해야만 함.
         """
         mock_f = MagicMock()
         mock_client = MagicMock()
-        event = {'client_msg_id': '59d1dbd3-245d-40ec-8898-ec5e32dae2ed', 'type': 'app_mention',
-                 'text': '<@U01BN035Y6L>', 'user': 'UQJ8HQJG5', 'ts': '1689437594.220999', 'blocks': [
-                {'type': 'rich_text', 'block_id': 'j7p', 'elements': [
-                    {'type': 'rich_text_section', 'elements': [{'type': 'user', 'user_id': 'U01BN035Y6L'}]}]}],
-                 'team': 'TQLEG4B38', 'thread_ts': '1689437200.559379', 'parent_user_id': 'UQJ8HQJG5',
-                 'channel': 'C03SZTDEDK3', 'event_ts': '1689437594.220999'}
+        event = {
+            "client_msg_id": "59d1dbd3-245d-40ec-8898-ec5e32dae2ed",
+            "type": "app_mention",
+            "text": "<@U01BN035Y6L>",
+            "user": "UQJ8HQJG5",
+            "ts": "1689437594.220999",
+            "blocks": [
+                {
+                    "type": "rich_text",
+                    "block_id": "j7p",
+                    "elements": [
+                        {
+                            "type": "rich_text_section",
+                            "elements": [{"type": "user", "user_id": "U01BN035Y6L"}],
+                        }
+                    ],
+                }
+            ],
+            "team": "TQLEG4B38",
+            "thread_ts": "1689437200.559379",
+            "parent_user_id": "UQJ8HQJG5",
+            "channel": "C03SZTDEDK3",
+            "event_ts": "1689437594.220999",
+        }
         mock_ack = MagicMock()
         mock_say = MagicMock()
         sut = loading_emoji_while_processing()(mock_f)
@@ -31,9 +49,18 @@ class TestDecorator(unittest.TestCase):
     def test_loading_emoji_triggerd_if_target_emoji(self):
         mock_f = MagicMock()
         mock_client = MagicMock()
-        event = {'type': 'reaction_added', 'user': 'UQJ8HQJG5', 'reaction': 'thinking',
-                 'item': {'type': 'message', 'channel': 'C03SZTDEDK3', 'ts': '1688801145.307229'},
-                 'item_user': 'UQJ8HQJG5', 'event_ts': '1688833113.003600'}
+        event = {
+            "type": "reaction_added",
+            "user": "UQJ8HQJG5",
+            "reaction": "thinking",
+            "item": {
+                "type": "message",
+                "channel": "C03SZTDEDK3",
+                "ts": "1688801145.307229",
+            },
+            "item_user": "UQJ8HQJG5",
+            "event_ts": "1688833113.003600",
+        }
         mock_ack = MagicMock()
         mock_say = MagicMock()
         sut = loading_emoji_while_processing(["thinking"])(mock_f)
@@ -44,13 +71,21 @@ class TestDecorator(unittest.TestCase):
         mock_client.reactions_add.assert_called()
         mock_client.reactions_remove.assert_called()
 
-
     def test_loading_emoji_not_triggerd_if_not_target_emoji(self):
         mock_f = MagicMock()
         mock_client = MagicMock()
-        event = {'type': 'reaction_added', 'user': 'UQJ8HQJG5', 'reaction': 'thinking',
-                 'item': {'type': 'message', 'channel': 'C03SZTDEDK3', 'ts': '1688801145.307229'},
-                 'item_user': 'UQJ8HQJG5', 'event_ts': '1688833113.003600'}
+        event = {
+            "type": "reaction_added",
+            "user": "UQJ8HQJG5",
+            "reaction": "thinking",
+            "item": {
+                "type": "message",
+                "channel": "C03SZTDEDK3",
+                "ts": "1688801145.307229",
+            },
+            "item_user": "UQJ8HQJG5",
+            "event_ts": "1688833113.003600",
+        }
         mock_ack = MagicMock()
         mock_say = MagicMock()
         sut = loading_emoji_while_processing(["wink"])(mock_f)

--- a/test/util/test_bigchat_event.py
+++ b/test/util/test_bigchat_event.py
@@ -1,0 +1,77 @@
+import unittest
+
+from util.bigchat_event import (
+    ics_token,
+    parse_sheet_name,
+    to_gcal_link,
+    to_ics,
+    verify_ics_token,
+)
+
+
+class TestParseSheetName(unittest.TestCase):
+    def test_valid(self):
+        event = parse_sheet_name("AI 밋업 26-08-20 19:00~21:00")
+
+        assert event is not None
+        assert event.name == "AI 밋업"
+        assert event.start.strftime("%Y-%m-%d %H:%M") == "2026-08-20 19:00"
+        assert event.end.strftime("%Y-%m-%d %H:%M") == "2026-08-20 21:00"
+
+    def test_invalid_format(self):
+        for sheet_name in [
+            "빅챗 23-07-31",  # 시간 없음 (구형식)
+            "AI 밋업 2026-08-20 19:00~21:00",  # yyyy
+            "AI 밋업 26-08-20 19:00-21:00",  # ~ 대신 -
+            "26-08-20 19:00~21:00",  # 이름 없음
+            "",
+        ]:
+            assert parse_sheet_name(sheet_name) is None, sheet_name
+
+    def test_nonexistent_datetime_rejected(self):
+        assert parse_sheet_name("AI 밋업 26-02-30 19:00~21:00") is None  # 2/30
+        assert parse_sheet_name("AI 밋업 26-08-20 25:00~26:00") is None  # 25시
+
+    def test_end_not_after_start_rejected(self):
+        assert parse_sheet_name("AI 밋업 26-08-20 21:00~19:00") is None
+        assert parse_sheet_name("AI 밋업 26-08-20 19:00~19:00") is None
+
+
+class TestCalendarLinks(unittest.TestCase):
+    def setUp(self):
+        self.event = parse_sheet_name("AI meetup 26-08-20 19:00~21:00")
+
+    def test_gcal_link(self):
+        link = to_gcal_link(self.event)
+
+        assert link.startswith("https://calendar.google.com/calendar/render?")
+        assert "action=TEMPLATE" in link
+        assert "text=AI+meetup" in link
+        assert "dates=20260820T190000%2F20260820T210000" in link
+        assert "ctz=Asia%2FSeoul" in link
+
+    def test_ics(self):
+        ics = to_ics(self.event, uid="bigchat-123@ausg-anna")
+
+        assert "BEGIN:VCALENDAR" in ics
+        assert "UID:bigchat-123@ausg-anna" in ics
+        assert "DTSTART:20260820T100000Z" in ics  # KST 19:00 = UTC 10:00
+        assert "DTEND:20260820T120000Z" in ics
+        assert "SUMMARY:AI meetup" in ics
+
+    def test_ics_escapes_special_chars(self):
+        event = parse_sheet_name("반가워, AUSG; friends 26-08-20 19:00~21:00")
+
+        ics = to_ics(event, uid="uid")
+
+        assert "SUMMARY:반가워\\, AUSG\\; friends" in ics
+
+
+class TestIcsToken(unittest.TestCase):
+    def test_verify_roundtrip(self):
+        token = ics_token("secret", 161837744)
+
+        assert verify_ics_token("secret", 161837744, token) is True
+        assert verify_ics_token("secret", 161837745, token) is False
+        assert verify_ics_token("other-secret", 161837744, token) is False
+        assert verify_ics_token("secret", 161837744, "") is False

--- a/test/util/test_utils.py
+++ b/test/util/test_utils.py
@@ -5,55 +5,32 @@ from util.utils import search_value, strip_multiline, with_retry
 
 class TestUtils(unittest.TestCase):
     def test_find_str(self):
-        sample = {
-            "key": "value"
-        }
+        sample = {"key": "value"}
         assert search_value(sample, "key") == "value"
 
     def test_find_dict(self):
-        sample = {
-            "key": {
-                "sub_key": "sub_value"
-            }
-        }
+        sample = {"key": {"sub_key": "sub_value"}}
         assert search_value(sample, "key")["sub_key"] == "sub_value"
 
     def test_find_nested_dict(self):
-        sample = {
-            "key": {
-                "sub_key": {
-                    "sub_sub_key" : "sub_sub_value"
-                }
-            }
-        }
+        sample = {"key": {"sub_key": {"sub_sub_key": "sub_sub_value"}}}
         assert search_value(sample, "sub_key")["sub_sub_key"] == "sub_sub_value"
 
     def test_find_list(self):
-        sample = {
-            "key": ["a", "b", "c"]
-        }
+        sample = {"key": ["a", "b", "c"]}
         assert search_value(sample, "key")[1] == "b"
 
     def test_find_nested_list(self):
-        sample = {
-            "key":{
-                "sub_key": ["a", "b", "c"]
-            }
-        }
+        sample = {"key": {"sub_key": ["a", "b", "c"]}}
         assert search_value(sample, "sub_key")[0] == "a"
         assert search_value(sample, "sub_key")[1] == "b"
         assert search_value(sample, "sub_key")[2] == "c"
 
     def test_find_deep_nested_list(self):
-        sample = {
-            "key":{
-                "sub_key": ["a", {"sub_sub_key" : ["aa", "bb", "cc"]}, "c"]
-            }
-        }
+        sample = {"key": {"sub_key": ["a", {"sub_sub_key": ["aa", "bb", "cc"]}, "c"]}}
         assert search_value(sample, "sub_sub_key")[0] == "aa"
         assert search_value(sample, "sub_sub_key")[1] == "bb"
         assert search_value(sample, "sub_sub_key")[2] == "cc"
-
 
     def test_find_fail(self):
         sample = {}
@@ -74,32 +51,41 @@ class TestStripMultiline(unittest.TestCase):
         학교/회사: "siwon school"
         ```
         (참고로 이 메시지는 너만 볼 수 있어!)"""
-        assert strip_multiline(sample) == """<@ABCDE12345> 네 신청 정보를 아래와 같이 등록했어. 바뀐 부분이 있다면 운영진에게 DM으로 알려줘!
+        assert (
+            strip_multiline(sample)
+            == """<@ABCDE12345> 네 신청 정보를 아래와 같이 등록했어. 바뀐 부분이 있다면 운영진에게 DM으로 알려줘!
 ```
 핸드폰: "010-1234-5678
 이메일: "abcde@gmail.com"
 학교/회사: "siwon school"
 ```
 (참고로 이 메시지는 너만 볼 수 있어!)"""
+        )
 
     def test_multiline_with_various_blanks(self):
         sample = """
         A
             B
     C"""
-        assert strip_multiline(sample) == """    A
+        assert (
+            strip_multiline(sample)
+            == """    A
         B
 C"""
+        )
 
     def test_multiline_with_first_line(self):
         sample = """hello
         A
             B
     C"""
-        assert strip_multiline(sample, ignore_first_line=False) == """hello
+        assert (
+            strip_multiline(sample, ignore_first_line=False)
+            == """hello
         A
             B
     C"""
+        )
 
     def test_multiline_with_arguments(self):
         sample = """
@@ -107,19 +93,23 @@ C"""
         {}
         B
         {}"""
-        assert strip_multiline(sample,"A", "CCC") == """hello
+        assert (
+            strip_multiline(sample, "A", "CCC")
+            == """hello
 A
 B
 CCC"""
+        )
+
 
 class TestWithRetry(unittest.TestCase):
     def test_with_retry_success(self):
-        attempts=0
+        attempts = 0
 
         @with_retry(fixed_wait_time_in_sec=0.01)
         def always_succeed():
             nonlocal attempts
-            attempts+=1
+            attempts += 1
             return "success"
 
         self.assertEqual(always_succeed(), "success")
@@ -131,7 +121,7 @@ class TestWithRetry(unittest.TestCase):
         @with_retry(fixed_wait_time_in_sec=0.01)
         def always_fail():
             nonlocal attempts
-            attempts+=1
+            attempts += 1
             raise ValueError("failure")
 
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Closes #112 (parent: #111)

빅챗 등록(이모지 리액션) 완료 시 뜨는 only-visible-to-you 메시지에 캘린더 추가 버튼 2개를 제공한다.

## 변경 내용

### `새로운 빅챗` 명령 — strict 포맷 (`create_bigchat_sheet.py`)
- `새로운 빅챗 <이름> yy-MM-DD HH:mm~HH:mm` 포맷 강제 (예: `새로운 빅챗 AI 밋업 26-08-20 19:00~21:00`)
- 포맷 불일치, 존재하지 않는 날짜/시각, 종료≤시작 → ephemeral 안내 후 **생성 거절** (보정/추측 없음)
- **시트 이름 자체가 이벤트 정보 저장소** — 별도 메타시트/셀/캐시 없음. 시트 탭 이름을 고치면 이후 생성되는 링크에 자동 반영

### 등록 완료 메시지에 버튼 2개 (`join_bigchat.py`)
- 📅 **Google Calendar에 추가** — 템플릿 URL, 인증 불필요
- 📥 **.ics 다운로드** — 아래 신규 엔드포인트 링크
- 구형식 시트는 참가 신청은 기존대로 성공하고 버튼만 생략 (하위 호환, 통합 테스트로 보증)
- 버튼 생성 실패는 try/except로 격리 — 등록 자체에 영향 없음

### 신규 ics 엔드포인트 (`anna.py`)
- `GET /bigchat/<worksheet_id>/event.ics?token=<hmac>`
- token = HMAC-SHA256(`ICS_TOKEN_SECRET`, worksheet_id) — stateless 검증, constant-time 비교 (불일치 403)
- 요청 시점에 시트 제목을 읽어 ics 생성 (구형식/없는 시트 404), `Content-Type: text/calendar`
- `ICS_TOKEN_SECRET` 미설정 시 엔드포인트 404 + ics 버튼 미생성 (안전 기본값)

### 기타
- `util/bigchat_event.py` (신규): 시트 이름 파싱, gcal 링크/ics 생성(KST→UTC), HMAC 토큰 — 순수 함수 모듈
- `slack_client.send_message_only_visible_to_user`에 `blocks` 파라미터 추가
- 링크 버튼 클릭 ack용 no-op `@app.action` 핸들러 (미등록 시 버튼에 ⚠️ 표시됨)
- env 추가: `PUBLIC_BASE_URL` (기본 fly.dev 도메인), `ICS_TOKEN_SECRET`

## 테스트
- 46 passed — 파서/링크/토큰 단위 테스트 및 핸들러 테스트 신규 추가
- 스모크 테스트: ics 엔드포인트 정상 200(본문 검증) / 잘못된 토큰 403 / 구형식 시트 404

## 머지 후 운영 작업 (@roeniss)
1. `fly secrets set ICS_TOKEN_SECRET=$(openssl rand -hex 32)` — 설정 전까지 ics 버튼 자동 비활성 (gcal 버튼은 즉시 동작)
2. Slack 앱 콘솔 → Interactivity 활성화, Request URL: `https://anna-v2-2023.fly.dev/slack/events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ)_