### PR TITLE
fix: 시트가 삭제된 빅챗에 고고 이모지 처리 시 전용 안내 및 즉시 실패 처리

### DIFF
--- a/src/handler/bigchat/abandon_bigchat.py
+++ b/src/handler/bigchat/abandon_bigchat.py
@@ -1,6 +1,7 @@
 import re
 from typing import List
 
+from implementation.google_spreadsheet_client import WorksheetNotFound
 from implementation.member_finder import MemberNotFound, MemberLackInfo
 from implementation.slack_client import Message
 
@@ -57,7 +58,15 @@ class AbandonBigchat:
             )
             return False
 
-        self.gs_client.delete_row(worksheet_id, member.email)
+        try:
+            self.gs_client.delete_row(worksheet_id, member.email)
+        except WorksheetNotFound:
+            self.slack_client.send_message(
+                msg=f"<@{self.user}>, 이 빅챗의 신청 시트를 찾을 수 없어서 등록을 취소하지 못했어. "
+                f"이미 마감되었거나 삭제된 것 같아. 필요하면 운영진에게 알려줘!",
+                ts=self.ts,
+            )
+            return False
 
         self.slack_client.send_message_only_visible_to_user(
             msg=f"<@{self.user}>, 등록을 취소했어.",

--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -3,6 +3,7 @@ import re
 from typing import List, Optional
 
 from config.env_config import envs
+from implementation.google_spreadsheet_client import WorksheetNotFound
 from implementation.member_finder import MemberNotFound, MemberLackInfo
 from implementation.slack_client import Message
 from util.bigchat_event import parse_sheet_name, to_gcal_link, ics_token
@@ -105,7 +106,15 @@ class JoinBigchat:
             )
             return False
 
-        self.gs_client.append_row(worksheet_id, member.transform_for_spreadsheet())
+        try:
+            self.gs_client.append_row(worksheet_id, member.transform_for_spreadsheet())
+        except WorksheetNotFound:
+            self.slack_client.send_message(
+                msg=f"<@{self.user}>, 이 빅챗의 신청 시트를 찾을 수 없어. 이미 마감되었거나 삭제된 것 같아. "
+                f"모집이 진행 중인 빅챗이라면 운영진에게 알려줘!",
+                ts=self.ts,
+            )
+            return False
 
         self.slack_client.send_message(msg=f"<@{self.user}>, 등록 완료!", ts=self.ts)
         msg = strip_multiline(

--- a/src/implementation/google_spreadsheet_client.py
+++ b/src/implementation/google_spreadsheet_client.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 
 from dateutil.tz import gettz
 from gspread import service_account_from_dict, Worksheet, Spreadsheet
+from gspread.exceptions import WorksheetNotFound
 from gspread_formatting import set_column_width
 
 from config.env_config import envs
@@ -58,7 +59,7 @@ class GoogleSpreadsheetClient:
 
         return worksheet.id
 
-    @with_retry()
+    @with_retry(non_retryable_exceptions=(WorksheetNotFound,))
     def append_row(
         self,
         worksheet_id: int,
@@ -73,12 +74,12 @@ class GoogleSpreadsheetClient:
 
         worksheet.append_row(_values)
 
-    @with_retry()
+    @with_retry(non_retryable_exceptions=(WorksheetNotFound,))
     def get_values(self, worksheet_id: int, cell_range=None) -> List[List[str]]:
         worksheet = self._get_worksheet(worksheet_id)
         return worksheet.get_values(cell_range)
 
-    @with_retry()
+    @with_retry(non_retryable_exceptions=(WorksheetNotFound,))
     def get_worksheet_title(self, worksheet_id: int) -> str:
         return self._get_worksheet(worksheet_id).title
 
@@ -97,7 +98,7 @@ class GoogleSpreadsheetClient:
     def _get_spreadsheet(self) -> Spreadsheet:
         return self.gs_client.open_by_key(self.spreadsheet_id)
 
-    @with_retry()
+    @with_retry(non_retryable_exceptions=(WorksheetNotFound,))
     def _get_worksheet(self, worksheet_id: int) -> Worksheet:
         spreadsheet = self._get_spreadsheet()
         worksheet = spreadsheet.get_worksheet_by_id(worksheet_id)
@@ -118,7 +119,7 @@ class GoogleSpreadsheetClient:
 
         return worksheet_id
 
-    @with_retry()
+    @with_retry(non_retryable_exceptions=(WorksheetNotFound,))
     def delete_row(self, worksheet_id: int, query: str):
         """
         XXX: 실제로 삭제할 정보가 없어서 아무 동작을 하지 않아도 에러를 뱉지 않는다.

--- a/src/util/utils.py
+++ b/src/util/utils.py
@@ -54,9 +54,11 @@ def strip_multiline(text, *args, ignore_first_line=True):
     return result
 
 
-def with_retry(max_try_cnt=10, fixed_wait_time_in_sec=3):
+def with_retry(max_try_cnt=10, fixed_wait_time_in_sec=3, non_retryable_exceptions=()):
     """
     usage: @with_retry(3, 1)
+
+    :param non_retryable_exceptions: 재시도해도 성공할 수 없는 예외 타입 튜플. 잡지 않고 즉시 전파한다.
     """
 
     def decorator(func):
@@ -66,6 +68,8 @@ def with_retry(max_try_cnt=10, fixed_wait_time_in_sec=3):
             for attempt in range(max_try_cnt):
                 try:
                     return func(*args, **kwargs)
+                except non_retryable_exceptions:
+                    raise
                 except Exception as ex:
                     last_exception = ex
                     time.sleep(fixed_wait_time_in_sec)

--- a/test/handler/bigchat/test_abandon_bigchat.py
+++ b/test/handler/bigchat/test_abandon_bigchat.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from test.handler.bigchat.sample_data import create_sample_reaction_removed_event
 
 from handler.bigchat.abandon_bigchat import AbandonBigchat
+from implementation.google_spreadsheet_client import WorksheetNotFound
 from implementation.member_finder import Member
 from implementation.slack_client import Message
 
@@ -59,3 +60,45 @@ class TestAbandonBigchat(unittest.TestCase):
                 "msg"
             ]
         )
+
+    def test_run_with_deleted_sheet_notifies_user(self):
+        """시트가 이미 삭제된 경우, 전용 안내 메시지를 보내고 False 를 반환한다."""
+        event = create_sample_reaction_removed_event("gogo")
+        mock_slack_client = MagicMock()
+        mock_slack_client.get_replies.return_value = [
+            Message(
+                ts=event["item"]["ts"],
+                thread_ts="1689429129.825319",
+                channel="C03SZTDEDK3",
+                user="U01BN035Y6L",
+                text="새로운 빅챗, 등록 완료! <https://docs.google.com/spreadsheets/d/1FtKRO4gmlVg-Si0_CHt-tkpVd3LDTXdsoZ0u98MYd0k/edit#gid=161837744|구글스프레드 시트>",
+            ),
+        ]
+        mock_member_manager = MagicMock()
+        mock_member_manager.find.return_value = Member(
+            kor_name="문성혁",
+            eng_name="Moon Seonghyeok",
+            email="email",
+            phone="phone",
+            school_name_or_company_name="school_name_or_company_name",
+        )
+        mock_gs_client = MagicMock()
+        mock_gs_client.delete_row.side_effect = WorksheetNotFound("161837744")
+        sut = AbandonBigchat(
+            event,
+            "U01BN035Y6L",
+            "gogo",
+            mock_slack_client,
+            mock_member_manager,
+            mock_gs_client,
+        )
+
+        result = sut.run()
+
+        assert result is False
+        mock_slack_client.send_message.assert_called_once()
+        assert (
+            "이 빅챗의 신청 시트를 찾을 수 없어서 등록을 취소하지 못했어"
+            in mock_slack_client.send_message.call_args.kwargs["msg"]
+        )
+        mock_slack_client.send_message_only_visible_to_user.assert_not_called()

--- a/test/handler/bigchat/test_join_bigchat.py
+++ b/test/handler/bigchat/test_join_bigchat.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from test.handler.bigchat.sample_data import create_sample_reaction_added_event
 
 from handler.bigchat.join_bigchat import JoinBigchat
+from implementation.google_spreadsheet_client import WorksheetNotFound
 from implementation.member_finder import Member
 from implementation.slack_client import Message
 
@@ -94,6 +95,43 @@ class TestJoinBigchat(unittest.TestCase):
             ]
             is None
         )
+
+    def test_run_with_deleted_sheet_notifies_user(self):
+        """시트가 이미 삭제된 경우, 전용 안내 메시지를 보내고 False 를 반환한다."""
+        event = create_sample_reaction_added_event("gogo")
+        mock_slack_client = MagicMock()
+        mock_slack_client.get_replies.return_value = [
+            Message(
+                ts=event["item"]["ts"],
+                thread_ts="1689429129.825319",
+                channel="C03SZTDEDK3",
+                user="U01BN035Y6L",
+                text="새로운 빅챗, 등록 완료! <https://docs.google.com/spreadsheets/d/1FtKRO4gmlVg-Si0_CHt-tkpVd3LDTXdsoZ0u98MYd0k/edit#gid=161837744|구글스프레드 시트>",
+            ),
+        ]
+        mock_gs_client = MagicMock()
+        mock_gs_client.append_row.side_effect = WorksheetNotFound("161837744")
+        mock_member_manager = MagicMock()
+        mock_member_manager.find.return_value = Member(
+            kor_name="문성혁",
+            eng_name="Moon Seonghyeok",
+            email="email",
+            phone="phone",
+            school_name_or_company_name="school_name_or_company_name",
+        )
+        sut = JoinBigchat(
+            event, "gogo", mock_slack_client, mock_gs_client, mock_member_manager
+        )
+
+        result = sut.run()
+
+        assert result is False
+        mock_slack_client.send_message.assert_called_once()
+        assert (
+            "이 빅챗의 신청 시트를 찾을 수 없어"
+            in mock_slack_client.send_message.call_args.kwargs["msg"]
+        )
+        mock_slack_client.send_message_only_visible_to_user.assert_not_called()
 
     def test_build_calendar_blocks_with_new_format_sheet(self):
         event = create_sample_reaction_added_event("gogo")

--- a/test/util/test_utils.py
+++ b/test/util/test_utils.py
@@ -128,6 +128,19 @@ class TestWithRetry(unittest.TestCase):
             always_fail()
         self.assertEqual(attempts, 10)
 
+    def test_with_retry_non_retryable_exception_raises_immediately(self):
+        attempts = 0
+
+        @with_retry(fixed_wait_time_in_sec=0.01, non_retryable_exceptions=(KeyError,))
+        def always_fail_with_non_retryable():
+            nonlocal attempts
+            attempts += 1
+            raise KeyError("failure")
+
+        with self.assertRaises(KeyError):
+            always_fail_with_non_retryable()
+        self.assertEqual(attempts, 1)
+
     def test_with_retry_partial_success(self):
         attempts = 0
 


### PR DESCRIPTION
Closes #119

## 문제

시트(워크시트)가 이미 삭제된 상태에서 고고 이모지로 참가 신청(또는 이모지 제거로 취소)을 하면:

1. gspread의 `get_worksheet_by_id`가 던지는 `WorksheetNotFound`를 `_get_worksheet`(10회)와 `append_row`/`delete_row`(10회)의 중첩된 `@with_retry()`가 무의미하게 재시도해 **약 5분 30초 동안 블로킹**되고, 그동안 사용자 메시지에는 `loading` 이모지만 붙어 있었습니다.
2. 이후 전역 에러 핸들러(`catch_global_error`)로 떨어져 "한 번 더 시도해보라"는 부정확한 안내가 나갔습니다 — 시트가 삭제된 상태라 재시도해도 똑같이 실패합니다.

## 변경 사항

- **`util/utils.py`**: `with_retry`에 `non_retryable_exceptions` 파라미터를 추가해, 재시도해도 성공할 수 없는 예외는 잡지 않고 즉시 전파하도록 했습니다.
- **`implementation/google_spreadsheet_client.py`**: 워크시트에 접근하는 메서드(`append_row`, `get_values`, `get_worksheet_title`, `delete_row`, `_get_worksheet`)에서 `WorksheetNotFound`를 재시도 대상에서 제외했습니다.
- **`handler/bigchat/join_bigchat.py`**: `append_row`에서 `WorksheetNotFound` 발생 시, 기존 `MemberNotFound` 처리와 같은 방식으로 "이 빅챗의 신청 시트를 찾을 수 없어. 이미 마감되었거나 삭제된 것 같아" 안내를 스레드에 남기고 `False`를 반환합니다.
- **`handler/bigchat/abandon_bigchat.py`**: `delete_row`도 동일하게 처리합니다.

## 테스트

- `with_retry`의 non-retryable 예외 즉시 전파 테스트 추가
- 시트 삭제 상태에서의 `JoinBigchat.run` / `AbandonBigchat.run` 동작 테스트 추가
- `black --check`, `ruff check`, 전체 테스트 49개 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CCYitndmcRueohM9wwbLPX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CCYitndmcRueohM9wwbLPX)_