### PR TITLE
캘린더 일정 본문에 빅챗 소개글 포함 + gcal/ics 서버 경로 통일 (#111)

### DIFF
--- a/src/anna.py
+++ b/src/anna.py
@@ -15,7 +15,8 @@ from handler.controller import (
     subin_like_response,
 )
 from implementation.google_spreadsheet_client import GoogleSpreadsheetClient
-from util.bigchat_event import parse_sheet_name, to_ics, verify_ics_token
+from slack_sdk import WebClient
+from util.bigchat_event import ics_payload, parse_sheet_name, to_ics, verify_ics_token
 
 init_logger()
 
@@ -72,12 +73,27 @@ def health():
     return {"status": "ok"}
 
 
+def _fetch_bigchat_intro(channel: str, ts: str) -> str:
+    """스레드 첫 글(이벤트 소개글)을 클릭 시점에 읽어온다. 실패해도 ics 제공은 막지 않는다."""
+    try:
+        web_client = WebClient(token=envs.SLACK_BOT_TOKEN)
+        resp = web_client.conversations_replies(channel=channel, ts=ts, limit=1)
+        return resp["messages"][0]["text"]
+    except Exception as ex:
+        logging.getLogger(__name__).warning(f"Failed to fetch bigchat intro: {ex}")
+        return ""
+
+
 @flask_app.route("/bigchat/<int:worksheet_id>/event.ics", methods=["GET"])
 def bigchat_ics(worksheet_id: int):
     if not envs.ICS_TOKEN_SECRET:
         abort(404)
+    channel = request.args.get("channel", "")
+    ts = request.args.get("ts", "")
     if not verify_ics_token(
-        envs.ICS_TOKEN_SECRET, worksheet_id, request.args.get("token", "")
+        envs.ICS_TOKEN_SECRET,
+        ics_payload(worksheet_id, channel, ts),
+        request.args.get("token", ""),
     ):
         abort(403)
 
@@ -93,8 +109,9 @@ def bigchat_ics(worksheet_id: int):
     if not event:
         abort(404)
 
+    description = _fetch_bigchat_intro(channel, ts) if channel and ts else ""
     return Response(
-        to_ics(event, uid=f"bigchat-{worksheet_id}@ausg-anna"),
+        to_ics(event, uid=f"bigchat-{worksheet_id}@ausg-anna", description=description),
         mimetype="text/calendar",
         headers={"Content-Disposition": 'attachment; filename="event.ics"'},
     )

--- a/src/anna.py
+++ b/src/anna.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from flask import Flask, Response, abort, request
+from flask import Flask, Response, abort, redirect, request
 from slack_bolt import App
 from slack_bolt.adapter.flask import SlackRequestHandler
 
@@ -16,7 +16,13 @@ from handler.controller import (
 )
 from implementation.google_spreadsheet_client import GoogleSpreadsheetClient
 from slack_sdk import WebClient
-from util.bigchat_event import ics_payload, parse_sheet_name, to_ics, verify_ics_token
+from util.bigchat_event import (
+    calendar_payload,
+    parse_sheet_name,
+    to_gcal_link_truncated,
+    to_ics,
+    verify_calendar_token,
+)
 
 init_logger()
 
@@ -74,7 +80,9 @@ def health():
 
 
 def _fetch_bigchat_intro(channel: str, ts: str) -> str:
-    """스레드 첫 글(이벤트 소개글)을 클릭 시점에 읽어온다. 실패해도 ics 제공은 막지 않는다."""
+    """스레드 첫 글(이벤트 소개글)을 클릭 시점에 읽어온다. 실패해도 캘린더 제공은 막지 않는다."""
+    if not channel or not ts:
+        return ""
     try:
         web_client = WebClient(token=envs.SLACK_BOT_TOKEN)
         resp = web_client.conversations_replies(channel=channel, ts=ts, limit=1)
@@ -84,15 +92,15 @@ def _fetch_bigchat_intro(channel: str, ts: str) -> str:
         return ""
 
 
-@flask_app.route("/bigchat/<int:worksheet_id>/event.ics", methods=["GET"])
-def bigchat_ics(worksheet_id: int):
+def _load_bigchat_calendar_context(worksheet_id: int):
+    """gcal 리다이렉트와 ics 다운로드가 공유하는 검증/조회 경로. 반환: (event, intro_text)"""
     if not envs.ICS_TOKEN_SECRET:
         abort(404)
     channel = request.args.get("channel", "")
     ts = request.args.get("ts", "")
-    if not verify_ics_token(
+    if not verify_calendar_token(
         envs.ICS_TOKEN_SECRET,
-        ics_payload(worksheet_id, channel, ts),
+        calendar_payload(worksheet_id, channel, ts),
         request.args.get("token", ""),
     ):
         abort(403)
@@ -109,9 +117,23 @@ def bigchat_ics(worksheet_id: int):
     if not event:
         abort(404)
 
-    description = _fetch_bigchat_intro(channel, ts) if channel and ts else ""
+    return event, _fetch_bigchat_intro(channel, ts)
+
+
+@flask_app.route("/bigchat/<int:worksheet_id>/gcal", methods=["GET"])
+def bigchat_gcal(worksheet_id: int):
+    event, intro = _load_bigchat_calendar_context(worksheet_id)
+    # 302 (301 금지): 클릭 시점에 최신 시간/소개글로 새로 만드는 URL이라 영구 캐시되면 안 된다
+    response = redirect(to_gcal_link_truncated(event, intro), code=302)
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
+@flask_app.route("/bigchat/<int:worksheet_id>/event.ics", methods=["GET"])
+def bigchat_ics(worksheet_id: int):
+    event, intro = _load_bigchat_calendar_context(worksheet_id)
     return Response(
-        to_ics(event, uid=f"bigchat-{worksheet_id}@ausg-anna", description=description),
+        to_ics(event, uid=f"bigchat-{worksheet_id}@ausg-anna", description=intro),
         mimetype="text/calendar",
         headers={"Content-Disposition": 'attachment; filename="event.ics"'},
     )

--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -5,7 +5,14 @@ from typing import List, Optional
 from config.env_config import envs
 from implementation.member_finder import MemberNotFound, MemberLackInfo
 from implementation.slack_client import Message
-from util.bigchat_event import parse_sheet_name, to_gcal_link, ics_token
+from urllib.parse import urlencode
+
+from util.bigchat_event import (
+    ics_payload,
+    ics_token,
+    parse_sheet_name,
+    to_gcal_link_truncated,
+)
 from util.utils import strip_multiline
 
 logger = logging.getLogger(__name__)
@@ -36,9 +43,13 @@ class JoinBigchat:
         return None
 
     def _build_calendar_blocks(
-        self, msg: str, worksheet_id: int
+        self, msg: str, worksheet_id: int, intro_text: str
     ) -> Optional[List[dict]]:
-        """시트 이름에서 이벤트 정보를 파싱해 캘린더 버튼 블록을 만든다. 구형식 시트 등 파싱 불가면 None."""
+        """시트 이름에서 이벤트 정보를 파싱해 캘린더 버튼 블록을 만든다. 구형식 시트 등 파싱 불가면 None.
+
+        스레드 첫 글(intro_text)은 캘린더 일정의 본문이 된다 — gcal은 details 파라미터로
+        (버튼 url 길이 제한에 맞게 잘라서), ics는 클릭 시점에 서버가 슬랙에서 다시 읽어온다.
+        """
         try:
             sheet_name = self.gs_client.get_worksheet_title(worksheet_id)
             event = parse_sheet_name(sheet_name)
@@ -57,11 +68,15 @@ class JoinBigchat:
                     "text": "📅 Google Calendar에 추가",
                     "emoji": True,
                 },
-                "url": to_gcal_link(event),
+                "url": to_gcal_link_truncated(event, intro_text),
             }
         ]
         if envs.ICS_TOKEN_SECRET:
-            token = ics_token(envs.ICS_TOKEN_SECRET, worksheet_id)
+            token = ics_token(
+                envs.ICS_TOKEN_SECRET,
+                ics_payload(worksheet_id, self.channel, self.ts),
+            )
+            query = urlencode({"token": token, "channel": self.channel, "ts": self.ts})
             buttons.append(
                 {
                     "type": "button",
@@ -71,7 +86,7 @@ class JoinBigchat:
                         "text": "📥 .ics 다운로드",
                         "emoji": True,
                     },
-                    "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/event.ics?token={token}",
+                    "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/event.ics?{query}",
                 }
             )
 
@@ -121,7 +136,7 @@ class JoinBigchat:
         )
         self.slack_client.send_message_only_visible_to_user(
             msg=msg,
-            blocks=self._build_calendar_blocks(msg, worksheet_id),
+            blocks=self._build_calendar_blocks(msg, worksheet_id, messages[0].text),
             channel=self.channel,
             ts=self.ts,
             user_id=self.user,

--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -7,12 +7,7 @@ from implementation.member_finder import MemberNotFound, MemberLackInfo
 from implementation.slack_client import Message
 from urllib.parse import urlencode
 
-from util.bigchat_event import (
-    ics_payload,
-    ics_token,
-    parse_sheet_name,
-    to_gcal_link_truncated,
-)
+from util.bigchat_event import calendar_payload, calendar_token, parse_sheet_name
 from util.utils import strip_multiline
 
 logger = logging.getLogger(__name__)
@@ -43,13 +38,16 @@ class JoinBigchat:
         return None
 
     def _build_calendar_blocks(
-        self, msg: str, worksheet_id: int, intro_text: str
+        self, msg: str, worksheet_id: int
     ) -> Optional[List[dict]]:
         """시트 이름에서 이벤트 정보를 파싱해 캘린더 버튼 블록을 만든다. 구형식 시트 등 파싱 불가면 None.
 
-        스레드 첫 글(intro_text)은 캘린더 일정의 본문이 된다 — gcal은 details 파라미터로
-        (버튼 url 길이 제한에 맞게 잘라서), ics는 클릭 시점에 서버가 슬랙에서 다시 읽어온다.
+        두 버튼 모두 서명된 서버 URL을 가리킨다 — gcal은 302 리다이렉트, ics는 파일 다운로드.
+        서버가 클릭 시점에 시트 이름(시간)과 스레드 첫 글(일정 본문)을 새로 읽으므로 항상 최신이다.
         """
+        if not envs.ICS_TOKEN_SECRET:
+            return None
+
         try:
             sheet_name = self.gs_client.get_worksheet_title(worksheet_id)
             event = parse_sheet_name(sheet_name)
@@ -59,6 +57,11 @@ class JoinBigchat:
         if not event:
             return None
 
+        token = calendar_token(
+            envs.ICS_TOKEN_SECRET,
+            calendar_payload(worksheet_id, self.channel, self.ts),
+        )
+        query = urlencode({"token": token, "channel": self.channel, "ts": self.ts})
         buttons = [
             {
                 "type": "button",
@@ -68,27 +71,19 @@ class JoinBigchat:
                     "text": "📅 Google Calendar에 추가",
                     "emoji": True,
                 },
-                "url": to_gcal_link_truncated(event, intro_text),
-            }
+                "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/gcal?{query}",
+            },
+            {
+                "type": "button",
+                "action_id": "calendar_ics",
+                "text": {
+                    "type": "plain_text",
+                    "text": "📥 .ics 다운로드",
+                    "emoji": True,
+                },
+                "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/event.ics?{query}",
+            },
         ]
-        if envs.ICS_TOKEN_SECRET:
-            token = ics_token(
-                envs.ICS_TOKEN_SECRET,
-                ics_payload(worksheet_id, self.channel, self.ts),
-            )
-            query = urlencode({"token": token, "channel": self.channel, "ts": self.ts})
-            buttons.append(
-                {
-                    "type": "button",
-                    "action_id": "calendar_ics",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "📥 .ics 다운로드",
-                        "emoji": True,
-                    },
-                    "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/event.ics?{query}",
-                }
-            )
 
         return [
             {"type": "section", "text": {"type": "mrkdwn", "text": msg}},
@@ -136,7 +131,7 @@ class JoinBigchat:
         )
         self.slack_client.send_message_only_visible_to_user(
             msg=msg,
-            blocks=self._build_calendar_blocks(msg, worksheet_id, messages[0].text),
+            blocks=self._build_calendar_blocks(msg, worksheet_id),
             channel=self.channel,
             ts=self.ts,
             user_id=self.user,

--- a/src/util/bigchat_event.py
+++ b/src/util/bigchat_event.py
@@ -16,6 +16,9 @@ SHEET_NAME_PAT = re.compile(
     r"^(?P<name>.+) (?P<date>\d{2}-\d{2}-\d{2}) (?P<start>\d{2}:\d{2})~(?P<end>\d{2}:\d{2})$"
 )
 
+# Slack 버튼 url 필드의 최대 길이는 3000자
+SLACK_BUTTON_URL_LIMIT = 2900
+
 
 @dataclass
 class BigchatEvent:
@@ -46,46 +49,59 @@ def parse_sheet_name(sheet_name: str) -> Optional[BigchatEvent]:
     return BigchatEvent(name=match["name"].strip(), start=start, end=end)
 
 
-def to_gcal_link(event: BigchatEvent) -> str:
-    params = urlencode(
-        {
-            "action": "TEMPLATE",
-            "text": event.name,
-            "dates": f"{_fmt_local(event.start)}/{_fmt_local(event.end)}",
-            "ctz": "Asia/Seoul",
-        }
-    )
-    return f"https://calendar.google.com/calendar/render?{params}"
+def to_gcal_link(event: BigchatEvent, details: str = "") -> str:
+    params = {
+        "action": "TEMPLATE",
+        "text": event.name,
+        "dates": f"{_fmt_local(event.start)}/{_fmt_local(event.end)}",
+        "ctz": "Asia/Seoul",
+    }
+    if details:
+        params["details"] = details
+    return f"https://calendar.google.com/calendar/render?{urlencode(params)}"
 
 
-def to_ics(event: BigchatEvent, uid: str) -> str:
+def to_gcal_link_truncated(event: BigchatEvent, details: str = "") -> str:
+    """Slack 버튼 url 길이 제한에 맞을 때까지 details를 잘라낸 gcal 링크."""
+    link = to_gcal_link(event, details)
+    while len(link) > SLACK_BUTTON_URL_LIMIT and details:
+        details = details[: len(details) - 100]
+        link = to_gcal_link(event, details + "…" if details else "")
+    return link
+
+
+def to_ics(event: BigchatEvent, uid: str, description: str = "") -> str:
     # KST는 DST가 없으므로 UTC로 변환해 VTIMEZONE 블록을 생략한다
-    return "\r\n".join(
-        [
-            "BEGIN:VCALENDAR",
-            "VERSION:2.0",
-            "PRODID:-//AUSG//anna//KO",
-            "BEGIN:VEVENT",
-            f"UID:{uid}",
-            f"DTSTAMP:{_fmt_utc(datetime.now(tz=timezone.utc))}",
-            f"DTSTART:{_fmt_utc(event.start)}",
-            f"DTEND:{_fmt_utc(event.end)}",
-            f"SUMMARY:{_escape_ics_text(event.name)}",
-            "END:VEVENT",
-            "END:VCALENDAR",
-            "",
-        ]
-    )
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//AUSG//anna//KO",
+        "BEGIN:VEVENT",
+        f"UID:{uid}",
+        f"DTSTAMP:{_fmt_utc(datetime.now(tz=timezone.utc))}",
+        f"DTSTART:{_fmt_utc(event.start)}",
+        f"DTEND:{_fmt_utc(event.end)}",
+        f"SUMMARY:{_escape_ics_text(event.name)}",
+    ]
+    if description:
+        lines.append(f"DESCRIPTION:{_escape_ics_text(description)}")
+    lines += [
+        "END:VEVENT",
+        "END:VCALENDAR",
+    ]
+    return "\r\n".join([_fold_ics_line(line) for line in lines] + [""])
 
 
-def ics_token(secret: str, worksheet_id: int) -> str:
-    return hmac.new(
-        secret.encode(), str(worksheet_id).encode(), hashlib.sha256
-    ).hexdigest()
+def ics_payload(worksheet_id: int, channel: str, ts: str) -> str:
+    return f"{worksheet_id}:{channel}:{ts}"
 
 
-def verify_ics_token(secret: str, worksheet_id: int, token: str) -> bool:
-    return hmac.compare_digest(ics_token(secret, worksheet_id), token)
+def ics_token(secret: str, payload: str) -> str:
+    return hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
+
+
+def verify_ics_token(secret: str, payload: str, token: str) -> bool:
+    return hmac.compare_digest(ics_token(secret, payload), token)
 
 
 def _fmt_local(dt: datetime) -> str:
@@ -101,5 +117,23 @@ def _escape_ics_text(text: str) -> str:
         text.replace("\\", "\\\\")
         .replace(";", "\\;")
         .replace(",", "\\,")
+        .replace("\r\n", "\\n")
         .replace("\n", "\\n")
     )
+
+
+def _fold_ics_line(line: str) -> str:
+    """RFC 5545 3.1: 75 옥텟을 넘는 줄은 CRLF + 공백으로 접는다 (멀티바이트 문자는 중간에서 자르지 않음)."""
+    if len(line.encode("utf-8")) <= 75:
+        return line
+
+    parts, current = [], ""
+    for char in line:
+        limit = 75 if not parts else 74  # 이어지는 줄은 맨 앞 공백 1칸 몫을 뺀다
+        if len((current + char).encode("utf-8")) > limit:
+            parts.append(current)
+            current = char
+        else:
+            current += char
+    parts.append(current)
+    return "\r\n ".join(parts)

--- a/src/util/bigchat_event.py
+++ b/src/util/bigchat_event.py
@@ -16,8 +16,8 @@ SHEET_NAME_PAT = re.compile(
     r"^(?P<name>.+) (?P<date>\d{2}-\d{2}-\d{2}) (?P<start>\d{2}:\d{2})~(?P<end>\d{2}:\d{2})$"
 )
 
-# Slack 버튼 url 필드의 최대 길이는 3000자
-SLACK_BUTTON_URL_LIMIT = 2900
+# 302 리다이렉트로 내려주는 gcal URL의 안전 상한 (브라우저/구글 프론트엔드의 ~8k 제한 대비 여유)
+GCAL_URL_LIMIT = 6000
 
 
 @dataclass
@@ -61,10 +61,12 @@ def to_gcal_link(event: BigchatEvent, details: str = "") -> str:
     return f"https://calendar.google.com/calendar/render?{urlencode(params)}"
 
 
-def to_gcal_link_truncated(event: BigchatEvent, details: str = "") -> str:
-    """Slack 버튼 url 길이 제한에 맞을 때까지 details를 잘라낸 gcal 링크."""
+def to_gcal_link_truncated(
+    event: BigchatEvent, details: str = "", limit: int = GCAL_URL_LIMIT
+) -> str:
+    """URL 길이 제한에 맞을 때까지 details를 잘라낸 gcal 링크."""
     link = to_gcal_link(event, details)
-    while len(link) > SLACK_BUTTON_URL_LIMIT and details:
+    while len(link) > limit and details:
         details = details[: len(details) - 100]
         link = to_gcal_link(event, details + "…" if details else "")
     return link
@@ -92,16 +94,17 @@ def to_ics(event: BigchatEvent, uid: str, description: str = "") -> str:
     return "\r\n".join([_fold_ics_line(line) for line in lines] + [""])
 
 
-def ics_payload(worksheet_id: int, channel: str, ts: str) -> str:
+def calendar_payload(worksheet_id: int, channel: str, ts: str) -> str:
     return f"{worksheet_id}:{channel}:{ts}"
 
 
-def ics_token(secret: str, payload: str) -> str:
+def calendar_token(secret: str, payload: str) -> str:
+    """gcal 리다이렉트와 ics 다운로드가 같은 토큰을 공유한다 (시크릿 env는 ICS_TOKEN_SECRET 그대로)."""
     return hmac.new(secret.encode(), payload.encode(), hashlib.sha256).hexdigest()
 
 
-def verify_ics_token(secret: str, payload: str, token: str) -> bool:
-    return hmac.compare_digest(ics_token(secret, payload), token)
+def verify_calendar_token(secret: str, payload: str, token: str) -> bool:
+    return hmac.compare_digest(calendar_token(secret, payload), token)
 
 
 def _fmt_local(dt: datetime) -> str:

--- a/test/handler/bigchat/test_join_bigchat.py
+++ b/test/handler/bigchat/test_join_bigchat.py
@@ -101,7 +101,7 @@ class TestJoinBigchat(unittest.TestCase):
         mock_gs_client.get_worksheet_title.return_value = "AI 밋업 26-08-20 19:00~21:00"
         sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
 
-        blocks = sut._build_calendar_blocks("등록했어", 161837744)
+        blocks = sut._build_calendar_blocks("등록했어", 161837744, "이번 빅챗 소개글입니다")
 
         assert blocks is not None
         buttons = blocks[1]["elements"]
@@ -109,6 +109,7 @@ class TestJoinBigchat(unittest.TestCase):
         assert buttons[0]["url"].startswith(
             "https://calendar.google.com/calendar/render?"
         )
+        assert "details=" in buttons[0]["url"]  # 스레드 첫 글이 일정 본문으로 들어간다
         # ICS_TOKEN_SECRET 미설정(기본값) 상태에서는 ics 버튼이 생기지 않는다
         assert all(b["action_id"] != "calendar_ics" for b in buttons)
 
@@ -118,6 +119,6 @@ class TestJoinBigchat(unittest.TestCase):
         mock_gs_client.get_worksheet_title.return_value = "빅챗 23-07-31"
         sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
 
-        blocks = sut._build_calendar_blocks("등록했어", 161837744)
+        blocks = sut._build_calendar_blocks("등록했어", 161837744, "소개글")
 
         assert blocks is None

--- a/test/handler/bigchat/test_join_bigchat.py
+++ b/test/handler/bigchat/test_join_bigchat.py
@@ -1,8 +1,9 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from test.handler.bigchat.sample_data import create_sample_reaction_added_event
 
+from config.env_config import envs
 from handler.bigchat.join_bigchat import JoinBigchat
 from implementation.member_finder import Member
 from implementation.slack_client import Message
@@ -101,17 +102,28 @@ class TestJoinBigchat(unittest.TestCase):
         mock_gs_client.get_worksheet_title.return_value = "AI 밋업 26-08-20 19:00~21:00"
         sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
 
-        blocks = sut._build_calendar_blocks("등록했어", 161837744, "이번 빅챗 소개글입니다")
+        with patch.object(envs, "ICS_TOKEN_SECRET", "testsecret"):
+            blocks = sut._build_calendar_blocks("등록했어", 161837744)
 
         assert blocks is not None
         buttons = blocks[1]["elements"]
-        assert buttons[0]["action_id"] == "calendar_gcal"
-        assert buttons[0]["url"].startswith(
-            "https://calendar.google.com/calendar/render?"
-        )
-        assert "details=" in buttons[0]["url"]  # 스레드 첫 글이 일정 본문으로 들어간다
-        # ICS_TOKEN_SECRET 미설정(기본값) 상태에서는 ics 버튼이 생기지 않는다
-        assert all(b["action_id"] != "calendar_ics" for b in buttons)
+        # 두 버튼 모두 같은 서명 쿼리를 달고 서버를 가리킨다 (gcal은 302 리다이렉트, ics는 다운로드)
+        assert [b["action_id"] for b in buttons] == ["calendar_gcal", "calendar_ics"]
+        gcal_url, ics_url = buttons[0]["url"], buttons[1]["url"]
+        assert "/bigchat/161837744/gcal?" in gcal_url
+        assert "/bigchat/161837744/event.ics?" in ics_url
+        assert gcal_url.split("?")[1] == ics_url.split("?")[1]
+        assert "token=" in gcal_url and "channel=" in gcal_url and "ts=" in gcal_url
+
+    def test_build_calendar_blocks_without_secret(self):
+        event = create_sample_reaction_added_event("gogo")
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_worksheet_title.return_value = "AI 밋업 26-08-20 19:00~21:00"
+        sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
+
+        blocks = sut._build_calendar_blocks("등록했어", 161837744)
+
+        assert blocks is None  # 시크릿 미설정이면 버튼 없이 기존 메시지만
 
     def test_build_calendar_blocks_with_old_format_sheet(self):
         event = create_sample_reaction_added_event("gogo")
@@ -119,6 +131,7 @@ class TestJoinBigchat(unittest.TestCase):
         mock_gs_client.get_worksheet_title.return_value = "빅챗 23-07-31"
         sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
 
-        blocks = sut._build_calendar_blocks("등록했어", 161837744, "소개글")
+        with patch.object(envs, "ICS_TOKEN_SECRET", "testsecret"):
+            blocks = sut._build_calendar_blocks("등록했어", 161837744)
 
         assert blocks is None

--- a/test/util/test_bigchat_event.py
+++ b/test/util/test_bigchat_event.py
@@ -1,9 +1,12 @@
 import unittest
 
 from util.bigchat_event import (
+    SLACK_BUTTON_URL_LIMIT,
+    ics_payload,
     ics_token,
     parse_sheet_name,
     to_gcal_link,
+    to_gcal_link_truncated,
     to_ics,
     verify_ics_token,
 )
@@ -50,6 +53,19 @@ class TestCalendarLinks(unittest.TestCase):
         assert "dates=20260820T190000%2F20260820T210000" in link
         assert "ctz=Asia%2FSeoul" in link
 
+    def test_gcal_link_with_details(self):
+        link = to_gcal_link(self.event, details="이번 빅챗은 강남에서 합니다")
+
+        assert "details=" in link
+
+    def test_gcal_link_truncated_fits_slack_button_limit(self):
+        long_intro = "빅챗 소개글 " * 2000
+
+        link = to_gcal_link_truncated(self.event, long_intro)
+
+        assert len(link) <= SLACK_BUTTON_URL_LIMIT
+        assert "details=" in link  # 잘리더라도 앞부분은 남는다
+
     def test_ics(self):
         ics = to_ics(self.event, uid="bigchat-123@ausg-anna")
 
@@ -58,20 +74,35 @@ class TestCalendarLinks(unittest.TestCase):
         assert "DTSTART:20260820T100000Z" in ics  # KST 19:00 = UTC 10:00
         assert "DTEND:20260820T120000Z" in ics
         assert "SUMMARY:AI meetup" in ics
+        assert "DESCRIPTION" not in ics  # 소개글 없으면 필드 생략
+
+    def test_ics_with_description(self):
+        ics = to_ics(self.event, uid="uid", description="이번 빅챗은\n강남에서 합니다")
+
+        assert "DESCRIPTION:이번 빅챗은\\n강남에서" in ics.replace("\r\n ", "")
 
     def test_ics_escapes_special_chars(self):
         event = parse_sheet_name("반가워, AUSG; friends 26-08-20 19:00~21:00")
 
         ics = to_ics(event, uid="uid")
 
-        assert "SUMMARY:반가워\\, AUSG\\; friends" in ics
+        assert "SUMMARY:반가워\\, AUSG\\; friends" in ics.replace("\r\n ", "")
+
+    def test_ics_folds_long_lines(self):
+        ics = to_ics(self.event, uid="uid", description="가나다라마바사아자차카타파하 " * 30)
+
+        for line in ics.split("\r\n"):
+            assert len(line.encode("utf-8")) <= 75, line
 
 
 class TestIcsToken(unittest.TestCase):
     def test_verify_roundtrip(self):
-        token = ics_token("secret", 161837744)
+        payload = ics_payload(161837744, "C03SZTDEDK3", "1688801145.307229")
+        token = ics_token("secret", payload)
 
-        assert verify_ics_token("secret", 161837744, token) is True
-        assert verify_ics_token("secret", 161837745, token) is False
-        assert verify_ics_token("other-secret", 161837744, token) is False
-        assert verify_ics_token("secret", 161837744, "") is False
+        assert verify_ics_token("secret", payload, token) is True
+        assert verify_ics_token("other-secret", payload, token) is False
+        assert verify_ics_token("secret", payload, "") is False
+        # channel/ts가 바뀌면 (다른 스레드로 바꿔치기) 검증 실패
+        tampered = ics_payload(161837744, "C_OTHER", "1688801145.307229")
+        assert verify_ics_token("secret", tampered, token) is False

--- a/test/util/test_bigchat_event.py
+++ b/test/util/test_bigchat_event.py
@@ -1,14 +1,14 @@
 import unittest
 
 from util.bigchat_event import (
-    SLACK_BUTTON_URL_LIMIT,
-    ics_payload,
-    ics_token,
+    GCAL_URL_LIMIT,
+    calendar_payload,
+    calendar_token,
     parse_sheet_name,
     to_gcal_link,
     to_gcal_link_truncated,
     to_ics,
-    verify_ics_token,
+    verify_calendar_token,
 )
 
 
@@ -58,12 +58,12 @@ class TestCalendarLinks(unittest.TestCase):
 
         assert "details=" in link
 
-    def test_gcal_link_truncated_fits_slack_button_limit(self):
+    def test_gcal_link_truncated_fits_url_limit(self):
         long_intro = "빅챗 소개글 " * 2000
 
         link = to_gcal_link_truncated(self.event, long_intro)
 
-        assert len(link) <= SLACK_BUTTON_URL_LIMIT
+        assert len(link) <= GCAL_URL_LIMIT
         assert "details=" in link  # 잘리더라도 앞부분은 남는다
 
     def test_ics(self):
@@ -95,14 +95,14 @@ class TestCalendarLinks(unittest.TestCase):
             assert len(line.encode("utf-8")) <= 75, line
 
 
-class TestIcsToken(unittest.TestCase):
+class TestCalendarToken(unittest.TestCase):
     def test_verify_roundtrip(self):
-        payload = ics_payload(161837744, "C03SZTDEDK3", "1688801145.307229")
-        token = ics_token("secret", payload)
+        payload = calendar_payload(161837744, "C03SZTDEDK3", "1688801145.307229")
+        token = calendar_token("secret", payload)
 
-        assert verify_ics_token("secret", payload, token) is True
-        assert verify_ics_token("other-secret", payload, token) is False
-        assert verify_ics_token("secret", payload, "") is False
+        assert verify_calendar_token("secret", payload, token) is True
+        assert verify_calendar_token("other-secret", payload, token) is False
+        assert verify_calendar_token("secret", payload, "") is False
         # channel/ts가 바뀌면 (다른 스레드로 바꿔치기) 검증 실패
-        tampered = ics_payload(161837744, "C_OTHER", "1688801145.307229")
-        assert verify_ics_token("secret", tampered, token) is False
+        tampered = calendar_payload(161837744, "C_OTHER", "1688801145.307229")
+        assert verify_calendar_token("secret", tampered, token) is False


### PR DESCRIPTION
#111 후속. PR #118 (#112) 위에 얹는 개선 2가지.

## 1. 스레드 첫 글을 캘린더 일정 본문으로 (`f9f4b38`)

:gogo: 리액션 대상인 스레드 첫 글(이벤트 소개글)이 캘린더 일정의 본문(description)으로 들어간다.

## 2. gcal 버튼도 서버 경유로 통일 (`13975ed`)

두 버튼 모두 동일한 서명 쿼리(`token`/`channel`/`ts`)로 서버를 가리킨다:

- `GET /bigchat/<worksheet_id>/gcal` → **302 리다이렉트**로 gcal 템플릿 URL 반환 (+`Cache-Control: no-store`)
- `GET /bigchat/<worksheet_id>/event.ics` → ics 파일 응답

검증/조회는 `_load_bigchat_calendar_context` 하나로 공유 — 클릭 시점에 시트 이름(시간)과 스레드 첫 글(본문)을 새로 읽으므로 **두 버튼 모두 항상 최신 데이터**를 반영한다.

이점:
- gcal도 소개글/시간 수정이 자동 반영 (기존엔 버튼 생성 시점 고정)
- Slack 버튼 url 3000자 제한 탈출 — 소개글 절단 한도가 6000자(URL 기준)로 완화
- 301이 아닌 302인 이유: 301은 브라우저가 영구 캐시해서 "클릭 시점 최신 생성"이 무력화됨

## 구현 디테일

- HMAC 페이로드가 `worksheet_id:channel:ts`로 확장 — channel/ts를 다른 스레드로 바꿔치기하면 403
- 슬랙 소개글 조회 실패 시에도 본문만 생략하고 캘린더는 정상 제공 (격리)
- ics DESCRIPTION 등 긴 줄은 RFC 5545 line folding(75옥텟) 적용
- `ICS_TOKEN_SECRET` 미설정 시 두 버튼 모두 미표시 (기존: gcal만 표시 — 이제 gcal도 서버 의존이므로. 프로덕션엔 시크릿 설정 완료 상태)
- 소개글은 슬랙 원문 그대로 들어감 (멘션이 `<@U123>` 형태로 보임 — 필요하면 후속에서 표시명 치환)

## 테스트

- 51 passed — 두 버튼 쿼리 공유, 시크릿 미설정 시 미표시, details 절단, DESCRIPTION 이스케이프/폴딩, 페이로드 변조 403 등 추가
- 스모크: gcal 302 + `no-store` + details 포함, ics 200 + DESCRIPTION, 잘못된 토큰 403

## 배포 참고

- 새 시크릿/콘솔 작업 없음 — 머지 후 배포만 하면 됨
- 배포 전에 발급된 버튼 URL(구 토큰 스킴)은 403이 됨 — ephemeral 메시지라 실질 영향 없음, 새로 리액션하면 새 버튼 발급

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ)_