### PR TITLE
fix: gcal 버튼을 직링크로 원복 (서버 302 경유 시 마케팅 페이지로 튕기는 문제)

### DIFF
--- a/src/anna.py
+++ b/src/anna.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from flask import Flask, Response, abort, redirect, request
+from flask import Flask, Response, abort, request
 from slack_bolt import App
 from slack_bolt.adapter.flask import SlackRequestHandler
 
@@ -19,7 +19,6 @@ from slack_sdk import WebClient
 from util.bigchat_event import (
     calendar_payload,
     parse_sheet_name,
-    to_gcal_link_truncated,
     to_ics,
     verify_calendar_token,
 )
@@ -93,7 +92,7 @@ def _fetch_bigchat_intro(channel: str, ts: str) -> str:
 
 
 def _load_bigchat_calendar_context(worksheet_id: int):
-    """gcal 리다이렉트와 ics 다운로드가 공유하는 검증/조회 경로. 반환: (event, intro_text)"""
+    """ics 다운로드의 검증/조회 경로. 반환: (event, intro_text)"""
     if not envs.ICS_TOKEN_SECRET:
         abort(404)
     channel = request.args.get("channel", "")
@@ -118,15 +117,6 @@ def _load_bigchat_calendar_context(worksheet_id: int):
         abort(404)
 
     return event, _fetch_bigchat_intro(channel, ts)
-
-
-@flask_app.route("/bigchat/<int:worksheet_id>/gcal", methods=["GET"])
-def bigchat_gcal(worksheet_id: int):
-    event, intro = _load_bigchat_calendar_context(worksheet_id)
-    # 302 (301 금지): 클릭 시점에 최신 시간/소개글로 새로 만드는 URL이라 영구 캐시되면 안 된다
-    response = redirect(to_gcal_link_truncated(event, intro), code=302)
-    response.headers["Cache-Control"] = "no-store"
-    return response
 
 
 @flask_app.route("/bigchat/<int:worksheet_id>/event.ics", methods=["GET"])

--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -8,7 +8,12 @@ from implementation.member_finder import MemberNotFound, MemberLackInfo
 from implementation.slack_client import Message
 from urllib.parse import urlencode
 
-from util.bigchat_event import calendar_payload, calendar_token, parse_sheet_name
+from util.bigchat_event import (
+    calendar_payload,
+    calendar_token,
+    parse_sheet_name,
+    to_gcal_link_truncated,
+)
 from util.utils import strip_multiline
 
 logger = logging.getLogger(__name__)
@@ -39,16 +44,15 @@ class JoinBigchat:
         return None
 
     def _build_calendar_blocks(
-        self, msg: str, worksheet_id: int
+        self, msg: str, worksheet_id: int, intro_text: str
     ) -> Optional[List[dict]]:
         """시트 이름에서 이벤트 정보를 파싱해 캘린더 버튼 블록을 만든다. 구형식 시트 등 파싱 불가면 None.
 
-        두 버튼 모두 서명된 서버 URL을 가리킨다 — gcal은 302 리다이렉트, ics는 파일 다운로드.
-        서버가 클릭 시점에 시트 이름(시간)과 스레드 첫 글(일정 본문)을 새로 읽으므로 항상 최신이다.
+        gcal 버튼은 캘린더 템플릿 URL 직링크여야 한다 — 서버 302 리다이렉트를 거치면
+        모바일 앱 링크 핸드오프가 끊겨 웹뷰(비로그인)로 열리고, 구글이 마케팅 페이지로
+        튕겨버린다. 소개글(intro_text)은 details 파라미터로 넣되 Slack 버튼 url 3000자
+        제한에 맞게 자른다. ics는 서버가 클릭 시점에 소개글을 새로 읽어 본문에 넣는다.
         """
-        if not envs.ICS_TOKEN_SECRET:
-            return None
-
         try:
             sheet_name = self.gs_client.get_worksheet_title(worksheet_id)
             event = parse_sheet_name(sheet_name)
@@ -58,11 +62,6 @@ class JoinBigchat:
         if not event:
             return None
 
-        token = calendar_token(
-            envs.ICS_TOKEN_SECRET,
-            calendar_payload(worksheet_id, self.channel, self.ts),
-        )
-        query = urlencode({"token": token, "channel": self.channel, "ts": self.ts})
         buttons = [
             {
                 "type": "button",
@@ -72,19 +71,27 @@ class JoinBigchat:
                     "text": "📅 Google Calendar에 추가",
                     "emoji": True,
                 },
-                "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/gcal?{query}",
-            },
-            {
-                "type": "button",
-                "action_id": "calendar_ics",
-                "text": {
-                    "type": "plain_text",
-                    "text": "📥 .ics 다운로드",
-                    "emoji": True,
-                },
-                "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/event.ics?{query}",
-            },
+                "url": to_gcal_link_truncated(event, intro_text),
+            }
         ]
+        if envs.ICS_TOKEN_SECRET:
+            token = calendar_token(
+                envs.ICS_TOKEN_SECRET,
+                calendar_payload(worksheet_id, self.channel, self.ts),
+            )
+            query = urlencode({"token": token, "channel": self.channel, "ts": self.ts})
+            buttons.append(
+                {
+                    "type": "button",
+                    "action_id": "calendar_ics",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "📥 .ics 다운로드",
+                        "emoji": True,
+                    },
+                    "url": f"{envs.PUBLIC_BASE_URL}/bigchat/{worksheet_id}/event.ics?{query}",
+                }
+            )
 
         return [
             {"type": "section", "text": {"type": "mrkdwn", "text": msg}},
@@ -140,7 +147,7 @@ class JoinBigchat:
         )
         self.slack_client.send_message_only_visible_to_user(
             msg=msg,
-            blocks=self._build_calendar_blocks(msg, worksheet_id),
+            blocks=self._build_calendar_blocks(msg, worksheet_id, messages[0].text),
             channel=self.channel,
             ts=self.ts,
             user_id=self.user,

--- a/src/util/bigchat_event.py
+++ b/src/util/bigchat_event.py
@@ -16,8 +16,8 @@ SHEET_NAME_PAT = re.compile(
     r"^(?P<name>.+) (?P<date>\d{2}-\d{2}-\d{2}) (?P<start>\d{2}:\d{2})~(?P<end>\d{2}:\d{2})$"
 )
 
-# 302 리다이렉트로 내려주는 gcal URL의 안전 상한 (브라우저/구글 프론트엔드의 ~8k 제한 대비 여유)
-GCAL_URL_LIMIT = 6000
+# Slack 버튼 url 필드의 최대 길이는 3000자
+SLACK_BUTTON_URL_LIMIT = 2900
 
 
 @dataclass
@@ -62,7 +62,7 @@ def to_gcal_link(event: BigchatEvent, details: str = "") -> str:
 
 
 def to_gcal_link_truncated(
-    event: BigchatEvent, details: str = "", limit: int = GCAL_URL_LIMIT
+    event: BigchatEvent, details: str = "", limit: int = SLACK_BUTTON_URL_LIMIT
 ) -> str:
     """URL 길이 제한에 맞을 때까지 details를 잘라낸 gcal 링크."""
     link = to_gcal_link(event, details)

--- a/test/handler/bigchat/test_join_bigchat.py
+++ b/test/handler/bigchat/test_join_bigchat.py
@@ -141,27 +141,28 @@ class TestJoinBigchat(unittest.TestCase):
         sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
 
         with patch.object(envs, "ICS_TOKEN_SECRET", "testsecret"):
-            blocks = sut._build_calendar_blocks("등록했어", 161837744)
+            blocks = sut._build_calendar_blocks("등록했어", 161837744, "이번 빅챗 소개글입니다")
 
         assert blocks is not None
         buttons = blocks[1]["elements"]
-        # 두 버튼 모두 같은 서명 쿼리를 달고 서버를 가리킨다 (gcal은 302 리다이렉트, ics는 다운로드)
         assert [b["action_id"] for b in buttons] == ["calendar_gcal", "calendar_ics"]
         gcal_url, ics_url = buttons[0]["url"], buttons[1]["url"]
-        assert "/bigchat/161837744/gcal?" in gcal_url
+        # gcal은 직링크여야 한다 — 서버 302 경유 시 모바일 앱 링크 핸드오프가 끊긴다
+        assert gcal_url.startswith("https://calendar.google.com/calendar/render?")
+        assert "details=" in gcal_url  # 스레드 첫 글이 일정 본문으로 들어간다
         assert "/bigchat/161837744/event.ics?" in ics_url
-        assert gcal_url.split("?")[1] == ics_url.split("?")[1]
-        assert "token=" in gcal_url and "channel=" in gcal_url and "ts=" in gcal_url
+        assert "token=" in ics_url and "channel=" in ics_url and "ts=" in ics_url
 
-    def test_build_calendar_blocks_without_secret(self):
+    def test_build_calendar_blocks_without_secret_has_gcal_only(self):
         event = create_sample_reaction_added_event("gogo")
         mock_gs_client = MagicMock()
         mock_gs_client.get_worksheet_title.return_value = "AI 밋업 26-08-20 19:00~21:00"
         sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
 
-        blocks = sut._build_calendar_blocks("등록했어", 161837744)
+        blocks = sut._build_calendar_blocks("등록했어", 161837744, "소개글")
 
-        assert blocks is None  # 시크릿 미설정이면 버튼 없이 기존 메시지만
+        buttons = blocks[1]["elements"]
+        assert [b["action_id"] for b in buttons] == ["calendar_gcal"]
 
     def test_build_calendar_blocks_with_old_format_sheet(self):
         event = create_sample_reaction_added_event("gogo")
@@ -170,6 +171,6 @@ class TestJoinBigchat(unittest.TestCase):
         sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
 
         with patch.object(envs, "ICS_TOKEN_SECRET", "testsecret"):
-            blocks = sut._build_calendar_blocks("등록했어", 161837744)
+            blocks = sut._build_calendar_blocks("등록했어", 161837744, "소개글")
 
         assert blocks is None

--- a/test/util/test_bigchat_event.py
+++ b/test/util/test_bigchat_event.py
@@ -1,7 +1,7 @@
 import unittest
 
 from util.bigchat_event import (
-    GCAL_URL_LIMIT,
+    SLACK_BUTTON_URL_LIMIT,
     calendar_payload,
     calendar_token,
     parse_sheet_name,
@@ -63,7 +63,7 @@ class TestCalendarLinks(unittest.TestCase):
 
         link = to_gcal_link_truncated(self.event, long_intro)
 
-        assert len(link) <= GCAL_URL_LIMIT
+        assert len(link) <= SLACK_BUTTON_URL_LIMIT
         assert "details=" in link  # 잘리더라도 앞부분은 남는다
 
     def test_ics(self):


### PR DESCRIPTION
#121 배포 후 발견된 리그레션 픽스.

## 문제

gcal 버튼 클릭 시 몇 번의 리다이렉트 끝에 구글 캘린더 **마케팅 페이지**(workspace.google.com/products/calendar)에 도달함.

**원인:** 버튼 URL이 `calendar.google.com` 직링크일 때는 모바일에서 앱 링크(universal link)로 구글 캘린더 앱에 바로 넘어가지만, 우리 서버 URL을 거치면 웹뷰가 먼저 뜨고 — **앱 링크 핸드오프는 서버 측 302 리다이렉트에서는 발동하지 않아서** — 비로그인 웹뷰로 `calendar.google.com`에 도달, 구글이 마케팅 페이지로 튕겨버림. 서버 리다이렉트 방식의 구조적 한계라 우회 불가.

## 수정

- **gcal 버튼: 직링크 원복** — 템플릿 URL을 버튼에 직접 탑재. 소개글은 `details` 파라미터로 넣되 Slack 버튼 url 3000자 제한에 맞게 절단 (`SLACK_BUTTON_URL_LIMIT` 복원)
- **ics 버튼: 서버 경로 유지** — 파일 다운로드는 웹뷰에서 문제없고, 클릭 시점 소개글 조회(항상 최신 본문) 이점도 유지
- `/bigchat/<id>/gcal` 라우트 제거, 시크릿 미설정 시 gcal 버튼만 표시하는 기존 동작 복원
- 재발 방지: gcal 버튼이 직링크인지 검증하는 테스트에 사유 주석 명시

## 테스트

54 passed (gcal 직링크 검증, 시크릿 미설정 시 gcal만 표시 포함). #120의 삭제된 시트 처리 변경과 충돌 없음 — 최신 main 위에서 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ)_