### PR TITLE
Dockerfile CMD를 gunicorn 직접 실행으로 변경 (#117)

### DIFF
--- a/.meta/deploy/Dockerfile
+++ b/.meta/deploy/Dockerfile
@@ -16,4 +16,6 @@ COPY ../../README.md .
 RUN ["poetry", "install"]
 
 # run the app
-CMD ["make", "wakeup_anna"]
+# 의존성은 빌드 시 이미 설치됨 — 부팅 시 재설치 없이 곧바로 서버를 띄워야
+# fly가 머신 시작 직후 검사하는 리스닝 소켓 체크(0.0.0.0:8080)를 통과한다
+CMD ["poetry", "run", "gunicorn", "--chdir", "src", "anna:flask_app", "--bind", "0.0.0.0:8080", "--workers", "1", "--threads", "8", "--timeout", "120"]


### PR DESCRIPTION
Closes #117

## 문제

배포 로그마다 아래 워닝이 찍힘 (서비스 영향은 없지만 배포/재시작마다 수 초의 불통 구간 발생):

```
WARNING The app is not listening on the expected address and will not be reachable by fly-proxy.
  - 0.0.0.0:8080
```

**원인:** CMD `make wakeup_anna`가 서버 기동 전에 `pip install poetry` + `poetry install`을 매 부팅마다 실행 — 의존성은 이미지 빌드 시 이미 설치돼 있어 사실상 no-op이지만 수 초를 소모하고, fly는 머신 시작 ~2초 후 리스닝 소켓을 검사하므로 그 시점엔 아직 8080 바인드 전.

## 수정

- CMD를 gunicorn 직접 실행으로 변경 (재설치 단계 제거)
- `make wakeup_anna`는 로컬 개발용으로 유지

## 검증

머지·배포 후 배포 로그에서 `WARNING The app is not listening...`이 사라졌는지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ)_