### PR TITLE
gcal 일정 본문 개선: permalink + 소개글 (#111)

### DIFF
--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -50,8 +50,9 @@ class JoinBigchat:
 
         gcal 버튼은 캘린더 템플릿 URL 직링크여야 한다 — 서버 302 리다이렉트를 거치면
         모바일 앱 링크 핸드오프가 끊겨 웹뷰(비로그인)로 열리고, 구글이 마케팅 페이지로
-        튕겨버린다. 소개글(intro_text)은 details 파라미터로 넣되 Slack 버튼 url 3000자
-        제한에 맞게 자른다. ics는 서버가 클릭 시점에 소개글을 새로 읽어 본문에 넣는다.
+        튕겨버린다. 직링크는 Slack 버튼 url 3000자 제한을 받아 소개글 전문을 못 싣기
+        때문에, gcal 본문에는 소개글 대신 원본 메시지 permalink를 넣는다 (permalink
+        조회 실패 시 잘린 소개글로 폴백). ics는 서버가 클릭 시점에 소개글 전문을 넣는다.
         """
         try:
             sheet_name = self.gs_client.get_worksheet_title(worksheet_id)
@@ -62,6 +63,8 @@ class JoinBigchat:
         if not event:
             return None
 
+        permalink = self.slack_client.get_permalink(self.channel, self.ts)
+        gcal_details = f"슬랙에서 소개글 보기: {permalink}" if permalink else intro_text
         buttons = [
             {
                 "type": "button",
@@ -71,7 +74,7 @@ class JoinBigchat:
                     "text": "📅 Google Calendar에 추가",
                     "emoji": True,
                 },
-                "url": to_gcal_link_truncated(event, intro_text),
+                "url": to_gcal_link_truncated(event, gcal_details),
             }
         ]
         if envs.ICS_TOKEN_SECRET:

--- a/src/handler/bigchat/join_bigchat.py
+++ b/src/handler/bigchat/join_bigchat.py
@@ -51,8 +51,9 @@ class JoinBigchat:
         gcal 버튼은 캘린더 템플릿 URL 직링크여야 한다 — 서버 302 리다이렉트를 거치면
         모바일 앱 링크 핸드오프가 끊겨 웹뷰(비로그인)로 열리고, 구글이 마케팅 페이지로
         튕겨버린다. 직링크는 Slack 버튼 url 3000자 제한을 받아 소개글 전문을 못 싣기
-        때문에, gcal 본문에는 소개글 대신 원본 메시지 permalink를 넣는다 (permalink
-        조회 실패 시 잘린 소개글로 폴백). ics는 서버가 클릭 시점에 소개글 전문을 넣는다.
+        때문에, gcal 본문은 맨 앞에 원본 메시지 permalink를 두고 그 아래에 소개글을
+        이어붙인다 — 절단은 뒤에서부터 일어나므로 잘려도 permalink는 항상 남는다.
+        ics는 서버가 클릭 시점에 소개글 전문을 넣는다.
         """
         try:
             sheet_name = self.gs_client.get_worksheet_title(worksheet_id)
@@ -64,7 +65,9 @@ class JoinBigchat:
             return None
 
         permalink = self.slack_client.get_permalink(self.channel, self.ts)
-        gcal_details = f"슬랙에서 소개글 보기: {permalink}" if permalink else intro_text
+        gcal_details = (
+            f"슬랙에서 소개글 보기: {permalink}\n\n{intro_text}" if permalink else intro_text
+        )
         buttons = [
             {
                 "type": "button",

--- a/src/implementation/slack_client.py
+++ b/src/implementation/slack_client.py
@@ -48,6 +48,15 @@ class SlackClient:
     def send_message_to_freetalk(self, msg: str):
         self.say(msg, channel="CQJ8HQWUV")
 
+    def get_permalink(self, channel: str, ts: str) -> Optional[str]:
+        """메시지 permalink를 반환. 실패 시 None."""
+        try:
+            resp = self.web_client.chat_getPermalink(channel=channel, message_ts=ts)
+            return resp["permalink"]
+        except SlackApiError as ex:
+            logger.warning(f"Failed to get permalink: {ex}")
+            return None
+
     def send_message_only_visible_to_user(
         self,
         msg: str,

--- a/test/handler/bigchat/test_join_bigchat.py
+++ b/test/handler/bigchat/test_join_bigchat.py
@@ -153,10 +153,26 @@ class TestJoinBigchat(unittest.TestCase):
         gcal_url, ics_url = buttons[0]["url"], buttons[1]["url"]
         # gcal은 직링크여야 한다 — 서버 302 경유 시 모바일 앱 링크 핸드오프가 끊긴다
         assert gcal_url.startswith("https://calendar.google.com/calendar/render?")
-        # gcal 본문에는 소개글 대신 원본 메시지 permalink가 들어간다 (버튼 url 3000자 제한)
+        # gcal 본문은 permalink가 맨 앞, 그 아래 소개글 — 잘려도 permalink는 항상 남는다
         assert "ausg.slack.com" in gcal_url
+        assert "%EC%86%8C%EA%B0%9C%EA%B8%80" in gcal_url  # "소개글" (intro도 이어붙음)
         assert "/bigchat/161837744/event.ics?" in ics_url
         assert "token=" in ics_url and "channel=" in ics_url and "ts=" in ics_url
+
+    def test_build_calendar_blocks_keeps_permalink_when_long_intro_truncated(self):
+        event = create_sample_reaction_added_event("gogo")
+        mock_slack_client = MagicMock()
+        mock_slack_client.get_permalink.return_value = (
+            "https://ausg.slack.com/archives/C03SZTDEDK3/p1688801145307229"
+        )
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_worksheet_title.return_value = "AI 밋업 26-08-20 19:00~21:00"
+        sut = JoinBigchat(event, "gogo", mock_slack_client, mock_gs_client, MagicMock())
+
+        blocks = sut._build_calendar_blocks("등록했어", 161837744, "긴 소개글 " * 2000)
+
+        gcal_url = blocks[1]["elements"][0]["url"]
+        assert "ausg.slack.com" in gcal_url  # 소개글이 잘려도 맨 앞의 permalink는 남는다
 
     def test_build_calendar_blocks_falls_back_to_intro_without_permalink(self):
         event = create_sample_reaction_added_event("gogo")

--- a/test/handler/bigchat/test_join_bigchat.py
+++ b/test/handler/bigchat/test_join_bigchat.py
@@ -136,9 +136,13 @@ class TestJoinBigchat(unittest.TestCase):
 
     def test_build_calendar_blocks_with_new_format_sheet(self):
         event = create_sample_reaction_added_event("gogo")
+        mock_slack_client = MagicMock()
+        mock_slack_client.get_permalink.return_value = (
+            "https://ausg.slack.com/archives/C03SZTDEDK3/p1688801145307229"
+        )
         mock_gs_client = MagicMock()
         mock_gs_client.get_worksheet_title.return_value = "AI 밋업 26-08-20 19:00~21:00"
-        sut = JoinBigchat(event, "gogo", MagicMock(), mock_gs_client, MagicMock())
+        sut = JoinBigchat(event, "gogo", mock_slack_client, mock_gs_client, MagicMock())
 
         with patch.object(envs, "ICS_TOKEN_SECRET", "testsecret"):
             blocks = sut._build_calendar_blocks("등록했어", 161837744, "이번 빅챗 소개글입니다")
@@ -149,9 +153,23 @@ class TestJoinBigchat(unittest.TestCase):
         gcal_url, ics_url = buttons[0]["url"], buttons[1]["url"]
         # gcal은 직링크여야 한다 — 서버 302 경유 시 모바일 앱 링크 핸드오프가 끊긴다
         assert gcal_url.startswith("https://calendar.google.com/calendar/render?")
-        assert "details=" in gcal_url  # 스레드 첫 글이 일정 본문으로 들어간다
+        # gcal 본문에는 소개글 대신 원본 메시지 permalink가 들어간다 (버튼 url 3000자 제한)
+        assert "ausg.slack.com" in gcal_url
         assert "/bigchat/161837744/event.ics?" in ics_url
         assert "token=" in ics_url and "channel=" in ics_url and "ts=" in ics_url
+
+    def test_build_calendar_blocks_falls_back_to_intro_without_permalink(self):
+        event = create_sample_reaction_added_event("gogo")
+        mock_slack_client = MagicMock()
+        mock_slack_client.get_permalink.return_value = None
+        mock_gs_client = MagicMock()
+        mock_gs_client.get_worksheet_title.return_value = "AI 밋업 26-08-20 19:00~21:00"
+        sut = JoinBigchat(event, "gogo", mock_slack_client, mock_gs_client, MagicMock())
+
+        blocks = sut._build_calendar_blocks("등록했어", 161837744, "이번 빅챗 소개글입니다")
+
+        gcal_url = blocks[1]["elements"][0]["url"]
+        assert "details=" in gcal_url  # permalink 실패 시 (잘린) 소개글로 폴백
 
     def test_build_calendar_blocks_without_secret_has_gcal_only(self):
         event = create_sample_reaction_added_event("gogo")


### PR DESCRIPTION
#111 후속 피드백 반영.

## 문제

gcal 버튼은 직링크 제약(#122) 때문에 Slack 버튼 url 3000자 제한을 받는다 — 한글 소개글 기준 인코딩 후 ~300자만 실려서 본문이 어중간하게 잘림. 제한을 늘릴 방법은 없음 (서버 리다이렉트는 #122에서 앱 핸드오프 문제로 기각).

## 수정

gcal 본문(details) 레이아웃:

```
슬랙에서 소개글 보기: <permalink>

<소개글 — 길면 뒤에서부터 잘림>
```

- **permalink가 맨 앞** — 절단은 뒤에서부터 일어나므로 소개글이 잘려도 permalink는 항상 남음. 클릭하면 슬랙 원본 스레드로 이동 (항상 전문·최신)
- 소개글은 남는 예산만큼 이어붙임 (잘리는 건 감수)
- permalink 조회(`chat.getPermalink`) 실패 시 소개글만으로 폴백
- **ics 본문은 소개글 전문 유지** (서버 생성이라 url 제한 없음)
- `SlackClient.get_permalink` 추가

## 테스트

56 passed — permalink+소개글 동시 포함, 긴 소개글 절단 시 permalink 생존, 조회 실패 폴백 테스트 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017VbfqYGNpHuCb8d5mRVjzZ